### PR TITLE
Added refresh and set to getAVAXAssetID on platformvm

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -127,15 +127,31 @@ export class PlatformVMAPI extends JRPCAPI {
   /**
    * Fetches the AVAX AssetID and returns it in a Promise.
    *
+   * @param refresh This function caches the response. Refresh = true will bust the cache.
+   * 
    * @returns The the provided string representing the AVAX AssetID
    */
-  getAVAXAssetID = async ():Promise<Buffer> => {
-    if (typeof this.AVAXAssetID === 'undefined') {
+  getAVAXAssetID = async (refresh:boolean = false):Promise<Buffer> => {
+    if (typeof this.AVAXAssetID === 'undefined' || refresh) {
       const assetID:string = await this.getStakingAssetID();
       this.AVAXAssetID = bintools.cb58Decode(assetID);
     }
     return this.AVAXAssetID;
   };
+  
+  /**
+   * Overrides the defaults and sets the cache to a specific AVAX AssetID
+   * 
+   * @param avaxAssetID A cb58 string or Buffer representing the AVAX AssetID
+   * 
+   * @returns The the provided string representing the AVAX AssetID
+   */
+  setAVAXAssetID = (avaxAssetID:string | Buffer) => {
+    if(typeof avaxAssetID === "string") {
+      avaxAssetID = bintools.cb58Decode(avaxAssetID);
+    }
+    this.AVAXAssetID = avaxAssetID;
+  }
 
   /**
    * Gets the default tx fee for this chain.


### PR DESCRIPTION
- PlatformVM's "getAVAXAssetID()" method now matches the AVM's "getAVAXAssetID()" function. 
- Added the "setAVAXAssetID()" method to PlatformVM.