### PR TITLE
Updated README for renamed function in bintools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ let newAddress1 = myKeychain.makeKey(); //returns a Buffer for the address
 You may also import your exsting private key into the KeyChain using either a Buffer...
 
 ```js
-let mypk = bintools.avaDeserialize("24jUJ9vZexUM6expyMcT48LBx27k1m7xpraoV62oSQAHdziao5"); //returns a Buffer
+let mypk = bintools.cb58Decode("24jUJ9vZexUM6expyMcT48LBx27k1m7xpraoV62oSQAHdziao5"); //returns a Buffer
 let newAddress2 = myKeychain.importKey(mypk); //returns a Buffer for the address
 ```
 


### PR DESCRIPTION
avaDeserialize doesn't exist in bintools anymore. It was renamed to cb58Decode.

Updating README code fragment to reflect