### PR TITLE
Remove Buffer polyfill from webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "node": ">=12.14.1",
     "npm": ">=6.14.6"
   },
+  "browser": {
+    "buffer": "./node_modules/buffer"
+  },
   "dependencies": {
     "axios": "0.19.2",
     "bech32": "1.1.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,4 +57,8 @@ module.exports = {
       },
     })],
   },
+  node: {
+    Buffer: false,
+    process: false
+  },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,8 +57,4 @@ module.exports = {
       },
     })],
   },
-  node: {
-    Buffer: false,
-    process: false
-  },
 };


### PR DESCRIPTION
Avalanche specifies a version of Buffer in package.json, but webpack (un)helpfully inserts its own (older) version of Buffer when building the `web/avalanche.js` file. By adding these lines to the webpack config we can tell it not to do that. It is suggested anyway for webpack 5 compatibility https://webpack.js.org/migrate/5/#test-webpack-5-compatibility.