### PR TITLE
Tests for the EVM

### DIFF
--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -18,7 +18,10 @@ import {
   Defaults, 
   PrimaryAssetAlias 
 } from '../../utils/constants';
-import { Tx, UnsignedTx } from './tx';
+import { 
+  Tx, 
+  UnsignedTx 
+} from './tx';
 import { EVMConstants } from './constants';
 import { 
   Asset,
@@ -54,9 +57,9 @@ export class EVMAPI extends JRPCAPI {
 
   protected blockchainAlias: string = undefined;
 
-  protected AVAXAssetID:Buffer = undefined;
+  protected AVAXAssetID: Buffer = undefined;
 
-  protected txFee:BN = undefined;
+  protected txFee: BN = undefined;
 
   /**
    * Gets the alias for the blockchainID if it exists, otherwise returns `undefined`.
@@ -191,8 +194,6 @@ export class EVMAPI extends JRPCAPI {
    * Overrides the defaults and sets the cache to a specific AVAX AssetID
    * 
    * @param avaxAssetID A cb58 string or Buffer representing the AVAX AssetID
-   * 
-   * @returns The the provided string representing the AVAX AssetID
    */
   setAVAXAssetID = (avaxAssetID: string | Buffer) => {
     if(typeof avaxAssetID === "string") {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -22,3 +22,11 @@ export interface Asset {
   assetID: Buffer
   denomination: number
 }
+export interface Payload {
+  result: {
+    name: string,
+    symbol: string,
+    assetID: string,
+    denomination: number
+  }
+}

--- a/src/utils/bintools.ts
+++ b/src/utils/bintools.ts
@@ -2,12 +2,12 @@
  * @packageDocumentation
  * @module Utils-BinTools
  */
+
 import BN from 'bn.js';
 import { Buffer } from 'buffer/';
 import createHash from 'create-hash';
 import * as bech32 from 'bech32';
 import { Base58 } from './base58';
-import { Defaults } from './constants';
 
 /**
  * A class containing tools useful in interacting with binary data cross-platform using
@@ -303,16 +303,17 @@ export default class BinTools {
    * @returns A {@link https://github.com/feross/buffer|Buffer} for the address if valid,
    * undefined if not valid.
    */
-  parseAddress = (addr:string,
-    blockchainID:string,
-    alias:string = undefined,
-    addrlen:number = 20):Buffer => {
-    const abc:Array<string> = addr.split('-');
+  parseAddress = (
+    addr: string,
+    blockchainID: string,
+    alias: string = undefined,
+    addrlen: number = 20): Buffer => {
+    const abc: string[] = addr.split('-');
     if (abc.length === 2 && ((alias && abc[0] === alias) || (blockchainID && abc[0] === blockchainID))) {
-        const addrbuff = this.stringToAddress(addr);
-        if ((addrlen && addrbuff.length === addrlen) || !(addrlen)) {
-          return addrbuff;
-        }
+      const addrbuff = this.stringToAddress(addr);
+      if ((addrlen && addrbuff.length === addrlen) || !(addrlen)) {
+        return addrbuff;
+      }
     }
     return undefined;
   };

--- a/tests/apis/evm/api.test.ts
+++ b/tests/apis/evm/api.test.ts
@@ -1,50 +1,54 @@
-import { Buffer } from 'buffer/';
-import mockAxios from 'jest-mock-axios';
-import { Avalanche, BN } from "src";
+import { Buffer } from "buffer/";
+import mockAxios from "jest-mock-axios";
 import { EVMAPI } from "src/apis/evm/api";
-import BinTools from 'src/utils/bintools';
-import * as bech32 from 'bech32';
-import { DefaultLocalGenesisPrivateKey, Defaults, PrivateKeyPrefix } from 'src/utils/constants';
-import { KeyChain } from 'src/apis/evm';
+import BinTools from "src/utils/bintools";
+import * as bech32 from "bech32";
+import createHash from "create-hash";
+import { Payload } from "../../../src/common/interfaces";
+import { Defaults } from "src/utils/constants";
+import { 
+  Avalanche, 
+  BN 
+} from "src";
 
 /**
  * @ignore
  */
 const bintools: BinTools = BinTools.getInstance();
 
-describe('EVMAPI', () => {
+describe("EVMAPI", () => {
   const networkid: number = 12345;
   const blockchainid: string = Defaults.network[networkid].C.blockchainID;
-  const ip: string = '127.0.0.1';
+  const ip: string = "127.0.0.1";
   const port: number = 9650;
   const protocol: string = 'https';
 
-  const username: string = 'AvaLabs';
-  const password: string = 'password';
+  const username: string = "AvaLabs";
+  const password: string = "password";
 
   const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkid, undefined, undefined, undefined, true);
   let api: EVMAPI;
 
 
-  const addrA: string = 'C-' + bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode("B6D4v1VtPYLbiUvYXtW4Px8oE9imC2vGW")));
-  const addrB: string = 'C-' + bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode("P5wdRuZeaDt28eHMP5S3w9ZdoBfo7wuzF")));
-  const addrC: string = 'C-' + bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode("6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV")));
+  const addrA: string = "C-" + bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode("B6D4v1VtPYLbiUvYXtW4Px8oE9imC2vGW")));
+  const addrB: string = "C-" + bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode("P5wdRuZeaDt28eHMP5S3w9ZdoBfo7wuzF")));
+  const addrC: string = "C-" + bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode("6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV")));
 
   beforeAll(() => {
-    api = new EVMAPI(avalanche, '/ext/bc/C/avax', blockchainid);
+    api = new EVMAPI(avalanche, "/ext/bc/C/avax", blockchainid);
   });
 
   afterEach(() => {
     mockAxios.reset();
   });
 
-  test('getBlockchainAlias', async () => {
+  test("getBlockchainAlias", async () => {
     const blockchainAliasC: string = "C";
     const blockchainAlias: string = api.getBlockchainAlias();
     expect(blockchainAlias).toBe(blockchainAliasC);
   });
 
-  test('setBlockchainAlias', async () => {
+  test("setBlockchainAlias", async () => {
     const blockchainAliasC: string = "C";
     const blockchainAliasX: string = "X";
     let blockchainAlias: string = api.getBlockchainAlias();
@@ -57,16 +61,16 @@ describe('EVMAPI', () => {
     expect(blockchainAlias).toBe(blockchainAliasX);
   });
 
-  test('getBlockchainID', async () => {
+  test("getBlockchainID", async () => {
     const blockchainIDC: string = "26sSDdFXoKeShAqVfvugUiUQKhMZtHYDLeBqmBfNfcdjziTrZA";
     const blockchainID: string = api.getBlockchainID();
     expect(blockchainID).toBe(blockchainIDC);
   });
 
-  test('refreshBlockchainID', async () => {
+  test("refreshBlockchainID", async () => {
     const n5bcID: string = Defaults.network[5].C["blockchainID"];
     const n12345bcID: string = Defaults.network[12345].C["blockchainID"];
-    const testAPI: EVMAPI = new EVMAPI(avalanche, '/ext/bc/C/avax', n5bcID);
+    const testAPI: EVMAPI = new EVMAPI(avalanche, "/ext/bc/C/avax", n5bcID);
     const bc1: string = testAPI.getBlockchainID();
     expect(bc1).toBe(n5bcID);
 
@@ -79,6 +83,93 @@ describe('EVMAPI', () => {
     expect(res).toBeTruthy();
     const bc3: string = testAPI.getBlockchainID();
     expect(bc3).toBe(n5bcID);
+  });
+
+  test("getAssetDescription as string", async () => {
+    const name: string = "AvalancheJS";
+    const symbol: string = "AJS";
+    const denomination: number = 10;
+    const assetIDBuf: Buffer = Buffer.from(createHash("sha256").update(name).digest());
+    const assetIDStr: string = bintools.cb58Encode(assetIDBuf);
+    const result: Promise<object> = api.getAssetDescription(assetIDStr);
+    const payload: Payload = {
+      result: {
+        name: name,
+        symbol: symbol,
+        assetID: assetIDStr,
+        denomination: denomination
+      },
+    };
+
+    const responseObj: {
+      data: Payload
+    } = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response: any = await result;
+
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(response.name).toBe(name);
+    expect(response.symbol).toBe(symbol);
+    expect(response.assetID.toString("hex")).toBe(assetIDBuf.toString("hex"));
+    expect(response.denomination).toBe(denomination);
+  });
+
+  test("getAssetDescription as Buffer", async () => {
+    const name: string = "AvalancheJS";
+    const symbol: string = "AJS";
+    const denomination: number = 10;
+    const assetIDBuf: Buffer = Buffer.from(createHash("sha256").update(name).digest());
+    const assetIDStr: string = bintools.cb58Encode(assetIDBuf);
+    const result: Promise<object> = api.getAssetDescription(assetIDBuf);
+    console.log("========")
+    console.log(result)
+    const payload: Payload = {
+      result: {
+        name: name,
+        symbol: symbol,
+        assetID: assetIDStr,
+        denomination: denomination
+      },
+    };
+
+    const responseObj: {
+      data: Payload
+    } = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response:any = await result;
+
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(response.name).toBe(name);
+    expect(response.symbol).toBe(symbol);
+    expect(response.assetID.toString("hex")).toBe(assetIDBuf.toString("hex"));
+    expect(response.denomination).toBe(denomination);
+  });
+
+  test("getAVAXAssetID refresh", async () => {
+    const assetID: string = "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe";
+
+    const refresh: boolean = true;
+    const result: Promise<object> = api.getAVAXAssetID(refresh);
+
+    const payload: object = {
+      result: {
+        assetID
+      }
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response: any = await result;
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(bintools.cb58Encode(response)).toBe(assetID);
   });
 
   test('importKey', async () => {

--- a/tests/apis/evm/api.test.ts
+++ b/tests/apis/evm/api.test.ts
@@ -1,9 +1,11 @@
+import { Buffer } from 'buffer/';
 import mockAxios from 'jest-mock-axios';
 import { Avalanche, BN } from "src";
 import { EVMAPI } from "src/apis/evm/api";
 import BinTools from 'src/utils/bintools';
 import * as bech32 from 'bech32';
-import { Defaults } from 'src/utils/constants';
+import { DefaultLocalGenesisPrivateKey, Defaults, PrivateKeyPrefix } from 'src/utils/constants';
+import { KeyChain } from 'src/apis/evm';
 
 /**
  * @ignore
@@ -34,6 +36,49 @@ describe('EVMAPI', () => {
 
   afterEach(() => {
     mockAxios.reset();
+  });
+
+  test('getBlockchainAlias', async () => {
+    const blockchainAliasC: string = "C";
+    const blockchainAlias: string = api.getBlockchainAlias();
+    expect(blockchainAlias).toBe(blockchainAliasC);
+  });
+
+  test('setBlockchainAlias', async () => {
+    const blockchainAliasC: string = "C";
+    const blockchainAliasX: string = "X";
+    let blockchainAlias: string = api.getBlockchainAlias();
+    // defaults to C
+    expect(blockchainAlias).toBe(blockchainAliasC);
+    // set to X
+    api.setBlockchainAlias(blockchainAliasX);
+    // confirm it's X
+    blockchainAlias = api.getBlockchainAlias();
+    expect(blockchainAlias).toBe(blockchainAliasX);
+  });
+
+  test('getBlockchainID', async () => {
+    const blockchainIDC: string = "26sSDdFXoKeShAqVfvugUiUQKhMZtHYDLeBqmBfNfcdjziTrZA";
+    const blockchainID: string = api.getBlockchainID();
+    expect(blockchainID).toBe(blockchainIDC);
+  });
+
+  test('refreshBlockchainID', async () => {
+    const n5bcID: string = Defaults.network[5].C["blockchainID"];
+    const n12345bcID: string = Defaults.network[12345].C["blockchainID"];
+    const testAPI: EVMAPI = new EVMAPI(avalanche, '/ext/bc/C/avax', n5bcID);
+    const bc1: string = testAPI.getBlockchainID();
+    expect(bc1).toBe(n5bcID);
+
+    let res: boolean = testAPI.refreshBlockchainID();
+    expect(res).toBeTruthy();
+    const bc2: string = testAPI.getBlockchainID();
+    expect(bc2).toBe(n12345bcID);
+
+    res = testAPI.refreshBlockchainID(n5bcID);
+    expect(res).toBeTruthy();
+    const bc3: string = testAPI.getBlockchainID();
+    expect(bc3).toBe(n5bcID);
   });
 
   test('importKey', async () => {
@@ -165,24 +210,5 @@ describe('EVMAPI', () => {
 
     expect(mockAxios.request).toHaveBeenCalledTimes(1);
     expect(response).toBe(txID);
-  });
-
-  test('refreshBlockchainID', async () => {
-    const n5bcID: string = Defaults.network[5].C["blockchainID"];
-    const n12345bcID: string = Defaults.network[12345].C["blockchainID"];
-    const testAPI: EVMAPI = new EVMAPI(avalanche, '/ext/bc/C/avax', n5bcID);
-    const bc1: string = testAPI.getBlockchainID();
-    expect(bc1).toBe(n5bcID);
-
-    let res: boolean = testAPI.refreshBlockchainID();
-    expect(res).toBeTruthy();
-    const bc2: string = testAPI.getBlockchainID();
-    expect(bc2).toBe(n12345bcID);
-
-    res = testAPI.refreshBlockchainID(n5bcID);
-    expect(res).toBeTruthy();
-    const bc3: string = testAPI.getBlockchainID();
-    expect(bc3).toBe(n5bcID);
-
   });
 });


### PR DESCRIPTION
## Add EVM tests for the following APIs

* `getBlockchainAlias`
* `setBlockchainAlias`
* `getBlockchainID`
* `refreshBlockchainID`
* `getAssetDescription as string`
* `getAssetDescription as Buffer`
* `getAVAXAssetID refresh`

## Miscellaneous

* Add `Payload` interface