### PR TITLE
Refactor to add UTXO Response interfaces

### DIFF
--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -6,7 +6,7 @@ import BN from 'bn.js';
 import { Buffer } from 'buffer/';
 import AvalancheCore from '../../avalanche';
 import BinTools from '../../utils/bintools';
-import { UTXOSet } from './utxos';
+import { UTXO, UTXOSet } from './utxos';
 import { AVMConstants } from './constants';
 import { KeyChain } from './keychain';
 import { Tx, UnsignedTx } from './tx';
@@ -16,11 +16,12 @@ import { InitialStates } from './initialstates';
 import { UnixNow } from '../../utils/helperfunctions';
 import { JRPCAPI } from '../../common/jrpcapi';
 import { RequestResponseData } from '../../common/apibase';
-import { Defaults, PlatformChainID, PrimaryAssetAlias, ONEAVAX } from '../../utils/constants';
+import { Defaults, PrimaryAssetAlias, ONEAVAX } from '../../utils/constants';
 import { MinterSet } from './minterset';
 import { PersistanceOptions } from '../../utils/persistenceoptions';
 import { OutputOwners } from '../../common/output';
 import { SECPTransferOutput } from './outputs';
+import { Index, AVMUTXOResponse } from 'src/common';
 
 /**
  * @ignore
@@ -648,16 +649,12 @@ export class AVMAPI extends JRPCAPI {
    *
    */
   getUTXOs = async (
-    addresses:Array<string> | string,
-    sourceChain:string = undefined,
+    addresses: string[] | string,
+    sourceChain: string = undefined,
     limit:number = 0,
-    startIndex:{address:string, utxo:string} = undefined,
-    persistOpts:PersistanceOptions = undefined
-  ):Promise<{
-    numFetched:number,
-    utxos:UTXOSet,
-    endIndex:{address:string, utxo:string}
-  }> => {
+    startIndex: Index = undefined,
+    persistOpts: PersistanceOptions = undefined
+  ):Promise<AVMUTXOResponse> => {
     
     if(typeof addresses === "string") {
       addresses = [addresses];
@@ -877,10 +874,10 @@ export class AVMAPI extends JRPCAPI {
     throw new Error("Error - AVMAPI.buildImportTx: Invalid destinationChain type: " + (typeof sourceChain) );
   }
   
-  const atomicUTXOs:UTXOSet = await (await this.getUTXOs(ownerAddresses, srcChain, 0, undefined)).utxos;
-  const avaxAssetID:Buffer = await this.getAVAXAssetID();
-
-  const atomics = atomicUTXOs.getAllUTXOs();
+  const avmUTXOResponse: AVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined)
+  const atomicUTXOs: UTXOSet = await avmUTXOResponse.utxos;
+  const avaxAssetID: Buffer = await this.getAVAXAssetID();
+  const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();
 
   if(atomics.length === 0){
     throw new Error("Error - AVMAPI.buildImportTx: No atomic UTXOs to import from " + srcChain + " using addresses: " + ownerAddresses.join(", ") );

--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -23,7 +23,7 @@ import { EVMConstants } from './constants';
 import { 
   Asset,
   Index, 
-  UTXOResponse 
+  EVMUTXOResponse 
 } from './../../common/interfaces'
 import { EVMInput } from './inputs';
 import { 
@@ -306,11 +306,7 @@ export class EVMAPI extends JRPCAPI {
     sourceChain: string = undefined,
     limit: number = 0,
     startIndex: Index = undefined
-  ): Promise<{
-    numFetched:number,
-    utxos,
-    endIndex: Index
-  }> => {
+  ): Promise<EVMUTXOResponse> => {
     if(typeof addresses === "string") {
       addresses = [addresses];
     }
@@ -521,8 +517,8 @@ export class EVMAPI extends JRPCAPI {
       // if there is no sourceChain passed in or the sourceChain is any data type other than a Buffer then throw an error
       throw new Error('Error - EVMAPI.buildImportTx: sourceChain is undefined or invalid sourceChain type.');
     }
-    const utxoResponse: UTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
-    const atomicUTXOs: UTXOSet = utxoResponse.utxos;
+    const evmUTXOResponse: EVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
+    const atomicUTXOs: UTXOSet = evmUTXOResponse.utxos;
     const avaxAssetID: Buffer = await this.getAVAXAssetID();
     const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();
 

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -4,6 +4,9 @@
  */
 
 import { Buffer } from 'buffer/';
+import { UTXOSet as AVMUTXOSet } from 'src/apis/avm';
+import { UTXOSet as EVMUTXOSet } from 'src/apis/evm';
+import { UTXOSet as PlatformVMUTXOSet } from 'src/apis/platformvm';
 
 export interface Index {
   address: string
@@ -12,8 +15,20 @@ export interface Index {
 
 export interface UTXOResponse {
   numFetched: number
-  utxos: any
+  encoding: string
   endIndex: Index
+}
+
+export interface AVMUTXOResponse extends UTXOResponse {
+  utxos: AVMUTXOSet
+}
+
+export interface PlatformVMUTXOResponse extends UTXOResponse {
+  utxos: PlatformVMUTXOSet
+}
+
+export interface EVMUTXOResponse extends UTXOResponse {
+  utxos: EVMUTXOSet
 }
 
 export interface Asset {


### PR DESCRIPTION
Pass back an interface instead of object literal when fetching UTXO. This PR adds `AVMUTXOResponse`, `PlatformVMUTXOResponse` and `EVMUTXOResponse` interfaces.