### PR TITLE
Introducing CodecID 01 to AvalancheJS

### DIFF
--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -21,7 +21,8 @@ import { MinterSet } from './minterset';
 import { PersistanceOptions } from '../../utils/persistenceoptions';
 import { OutputOwners } from '../../common/output';
 import { SECPTransferOutput } from './outputs';
-import { Index, AVMUTXOResponse } from 'src/common';
+import { Index } from '../../../src/common';
+import { iAVMUTXOResponse, iGetBalanceParams, iGetBalanceResponse } from './interfaces';
 
 /**
  * @ignore
@@ -270,12 +271,13 @@ export class AVMAPI extends JRPCAPI {
      *
      * @returns Promise with the balance of the assetID as a {@link https://github.com/indutny/bn.js/|BN} on the provided address for the blockchain.
      */
-  getBalance = async (address:string, assetID:string):Promise<object> => {
+
+  getBalance = async (address:string, assetID:string):Promise<iGetBalanceResponse> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
       throw new Error(`Error - AVMAPI.getBalance: Invalid address format ${address}`);
     }
-    const params:any = {
+    const params:iGetBalanceParams = {
       address,
       assetID,
     };
@@ -654,7 +656,7 @@ export class AVMAPI extends JRPCAPI {
     limit:number = 0,
     startIndex: Index = undefined,
     persistOpts: PersistanceOptions = undefined
-  ):Promise<AVMUTXOResponse> => {
+  ):Promise<iAVMUTXOResponse> => {
     
     if(typeof addresses === "string") {
       addresses = [addresses];
@@ -874,8 +876,8 @@ export class AVMAPI extends JRPCAPI {
     throw new Error("Error - AVMAPI.buildImportTx: Invalid destinationChain type: " + (typeof sourceChain) );
   }
   
-  const avmUTXOResponse: AVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined)
-  const atomicUTXOs: UTXOSet = await avmUTXOResponse.utxos;
+  const avmUTXOResponse: iAVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined)
+  const atomicUTXOs: UTXOSet = avmUTXOResponse.utxos;
   const avaxAssetID: Buffer = await this.getAVAXAssetID();
   const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();
 

--- a/src/apis/avm/basetx.ts
+++ b/src/apis/avm/basetx.ts
@@ -61,9 +61,14 @@ export class BaseTx  extends StandardBaseTx<KeyPair, KeyChain>{
   /**
    * Returns the id of the [[BaseTx]]
    */
-  getTxType = ():number => {
-    return this._typeID;
-  }
+  getTxType = (codecID: number = 1): number => {
+    if(codecID === 0) {
+      return this._typeID;
+
+    } else if(codecID === 1)  {
+      return this._typeID;
+    }
+  } 
 
   /**
    * Takes a {@link https://github.com/feross/buffer|Buffer} containing an [[BaseTx]], parses it, populates the class, and returns the length of the BaseTx in bytes.

--- a/src/apis/avm/basetx.ts
+++ b/src/apis/avm/basetx.ts
@@ -61,7 +61,7 @@ export class BaseTx  extends StandardBaseTx<KeyPair, KeyChain>{
   /**
    * Returns the id of the [[BaseTx]]
    */
-  getTxType = (codecID: number = 1): number => {
+  getTxType = (): number => {
     return this._typeID;
   } 
 

--- a/src/apis/avm/basetx.ts
+++ b/src/apis/avm/basetx.ts
@@ -62,12 +62,7 @@ export class BaseTx  extends StandardBaseTx<KeyPair, KeyChain>{
    * Returns the id of the [[BaseTx]]
    */
   getTxType = (codecID: number = 1): number => {
-    if(codecID === 0) {
-      return this._typeID;
-
-    } else if(codecID === 1)  {
-      return this._typeID;
-    }
+    return this._typeID;
   } 
 
   /**

--- a/src/apis/avm/constants.ts
+++ b/src/apis/avm/constants.ts
@@ -12,15 +12,23 @@ export class AVMConstants {
 
   static SECPMINTOUTPUTID:number = 6;
 
+  static SECPMINTOUTPUTID_CODECONE:number = 65537;
+
   static SECPXFEROUTPUTID:number = 7;
+
+  static SECPXFEROUTPUTID_CODECONE:number = 65538;
 
   static NFTXFEROUTPUTID:number = 11;
 
   static NFTMINTOUTPUTID:number = 10;
 
-  static SECPINPUTID:number = 5;
+  static SECPXFERINPUTID:number = 5;
+
+  static SECPXFERINPUTID_CODECONE:number = 65536;
 
   static SECPMINTOPID:number = 8;
+
+  static SECPMINTOPID_CODECONE:number = 65539;
 
   static NFTMINTOPID:number = 12;
 
@@ -37,6 +45,8 @@ export class AVMConstants {
   static EXPORTTX:number = 4;
 
   static SECPCREDENTIAL:number = 9;
+  
+  static SECPCREDENTIAL_CODECONE:number = 65540;
 
   static NFTCREDENTIAL:number = 14;
 

--- a/src/apis/avm/constants.ts
+++ b/src/apis/avm/constants.ts
@@ -20,7 +20,11 @@ export class AVMConstants {
 
   static NFTXFEROUTPUTID:number = 11;
 
+  static NFTXFEROUTPUTID_CODECONE:number = 131073;
+
   static NFTMINTOUTPUTID:number = 10;
+
+  static NFTMINTOUTPUTID_CODECONE:number = 131072;
 
   static SECPXFERINPUTID:number = 5;
 
@@ -32,7 +36,11 @@ export class AVMConstants {
 
   static NFTMINTOPID:number = 12;
 
+  static NFTMINTOPID_CODECONE:number = 131074;
+
   static NFTXFEROPID:number = 13;
+
+  static NFTXFEROPID_CODECONE:number = 131075;
 
   static BASETX:number = 0;
 
@@ -49,6 +57,8 @@ export class AVMConstants {
   static SECPCREDENTIAL_CODECONE:number = 65540;
 
   static NFTCREDENTIAL:number = 14;
+
+  static NFTCREDENTIAL_CODECONE:number = 131076;
 
   static ASSETIDLEN:number = 32;
 

--- a/src/apis/avm/createassettx.ts
+++ b/src/apis/avm/createassettx.ts
@@ -49,9 +49,14 @@ export class CreateAssetTx extends BaseTx {
   /**
    * Returns the id of the [[CreateAssetTx]]
    */
-  getTxType = ():number => {
-    return this._typeID;
-  }
+  getTxType = (codecID: number = 1): number => {
+    if(codecID === 0) {
+      return this._typeID;
+
+    } else if(codecID === 1)  {
+      return this._typeID;
+    }
+  } 
 
   /**
    * Returns the array of array of [[Output]]s for the initial state

--- a/src/apis/avm/createassettx.ts
+++ b/src/apis/avm/createassettx.ts
@@ -49,7 +49,7 @@ export class CreateAssetTx extends BaseTx {
   /**
    * Returns the id of the [[CreateAssetTx]]
    */
-  getTxType = (codecID: number = 1): number => {
+  getTxType = (): number => {
     return this._typeID;
   } 
 

--- a/src/apis/avm/createassettx.ts
+++ b/src/apis/avm/createassettx.ts
@@ -120,9 +120,9 @@ export class CreateAssetTx extends BaseTx {
   /**
      * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[CreateAssetTx]].
      */
-  toBuffer():Buffer {
-    const superbuff:Buffer = super.toBuffer();
-    const initstatebuff:Buffer = this.initialstate.toBuffer();
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
+    const superbuff:Buffer = super.toBuffer(codecID);
+    const initstatebuff:Buffer = this.initialstate.toBuffer(codecID);
 
     const namebuff:Buffer = Buffer.alloc(this.name.length);
     namebuff.write(this.name, 0, this.name.length, 'utf8');

--- a/src/apis/avm/createassettx.ts
+++ b/src/apis/avm/createassettx.ts
@@ -50,12 +50,7 @@ export class CreateAssetTx extends BaseTx {
    * Returns the id of the [[CreateAssetTx]]
    */
   getTxType = (codecID: number = 1): number => {
-    if(codecID === 0) {
-      return this._typeID;
-
-    } else if(codecID === 1)  {
-      return this._typeID;
-    }
+    return this._typeID;
   } 
 
   /**

--- a/src/apis/avm/credentials.ts
+++ b/src/apis/avm/credentials.ts
@@ -33,6 +33,14 @@ export class SECPCredential extends Credential {
     return this._typeID;
   }
 
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.SECPCREDENTIAL;
+    } else if (codecID === 1) {
+      return AVMConstants.SECPCREDENTIAL_CODECONE;
+    }
+  }
+
   clone():this {
     let newbase:SECPCredential = new SECPCredential();
     newbase.fromBuffer(this.toBuffer());
@@ -58,6 +66,14 @@ export class NFTCredential extends Credential {
 
   getCredentialID():number {
     return this._typeID;
+  }
+
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.NFTCREDENTIAL;
+    } else if (codecID === 1) {
+      return AVMConstants.NFTCREDENTIAL_CODECONE;
+    }
   }
 
   clone():this {

--- a/src/apis/avm/credentials.ts
+++ b/src/apis/avm/credentials.ts
@@ -14,9 +14,9 @@ import { Credential } from '../../common/credentials';
  * @returns An instance of an [[Credential]]-extended class.
  */
 export const SelectCredentialClass = (credid:number, ...args:Array<any>):Credential => {
-  if (credid === AVMConstants.SECPCREDENTIAL) {
+  if (credid === AVMConstants.SECPCREDENTIAL || credid === AVMConstants.SECPCREDENTIAL_CODECONE) {
     return new SECPCredential(...args);
-  } if (credid === AVMConstants.NFTCREDENTIAL) {
+  } if (credid === AVMConstants.NFTCREDENTIAL || credid === AVMConstants.NFTCREDENTIAL_CODECONE) {
     return new NFTCredential(...args);
   }
   /* istanbul ignore next */

--- a/src/apis/avm/exporttx.ts
+++ b/src/apis/avm/exporttx.ts
@@ -113,12 +113,12 @@ export class ExportTx extends BaseTx {
   /**
      * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[ExportTx]].
      */
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     if(typeof this.destinationChain === "undefined") {
       throw new Error("ExportTx.toBuffer -- this.destinationChain is undefined");
     }
     this.numOuts.writeUInt32BE(this.exportOuts.length, 0);
-    let barr:Array<Buffer> = [super.toBuffer(), this.destinationChain, this.numOuts];
+    let barr:Array<Buffer> = [super.toBuffer(codecID), this.destinationChain, this.numOuts];
     this.exportOuts = this.exportOuts.sort(TransferableOutput.comparator());
     for(let i = 0; i < this.exportOuts.length; i++) {
         barr.push(this.exportOuts[i].toBuffer());

--- a/src/apis/avm/importtx.ts
+++ b/src/apis/avm/importtx.ts
@@ -92,15 +92,15 @@ export class ImportTx extends BaseTx {
   /**
    * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[ImportTx]].
    */
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     if(typeof this.sourceChain === "undefined") {
       throw new Error("ImportTx.toBuffer -- this.sourceChain is undefined");
     }
     this.numIns.writeUInt32BE(this.importIns.length, 0);
-    let barr:Array<Buffer> = [super.toBuffer(), this.sourceChain, this.numIns];
+    let barr:Array<Buffer> = [super.toBuffer(codecID), this.sourceChain, this.numIns];
     this.importIns = this.importIns.sort(TransferableInput.comparator());
     for(let i = 0; i < this.importIns.length; i++) {
-        barr.push(this.importIns[i].toBuffer());
+        barr.push(this.importIns[i].toBuffer(codecID));
     }
     return Buffer.concat(barr);
   }

--- a/src/apis/avm/initialstates.ts
+++ b/src/apis/avm/initialstates.ts
@@ -85,7 +85,7 @@ export class InitialStates extends Serializable{
     return offset;
   }
 
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     const buff:Array<Buffer> = [];
     const keys:Array<number> = Object.keys(this.fxs).map((k) => parseInt(k, 10)).sort();
     const klen:Buffer = Buffer.alloc(4);
@@ -102,7 +102,7 @@ export class InitialStates extends Serializable{
       buff.push(statelen);
       for (let j = 0; j < initialState.length; j++) {
         const outputid:Buffer = Buffer.alloc(4);
-        outputid.writeInt32BE(initialState[j].getOutputID(), 0);
+        outputid.writeInt32BE(initialState[j].getEncodingID(codecID) as number, 0);
         buff.push(outputid);
         buff.push(initialState[j].toBuffer());
       }

--- a/src/apis/avm/inputs.ts
+++ b/src/apis/avm/inputs.ts
@@ -22,7 +22,7 @@ const serializer = Serialization.getInstance();
  * @returns An instance of an [[Input]]-extended class.
  */
 export const SelectInputClass = (inputid:number, ...args:Array<any>):Input => {
-  if (inputid === AVMConstants.SECPINPUTID) {
+  if (inputid === AVMConstants.SECPXFERINPUTID || inputid === AVMConstants.SECPXFERINPUTID_CODECONE) {
     return new SECPTransferInput(...args);
   }
   /* istanbul ignore next */
@@ -76,7 +76,7 @@ export abstract class AmountInput extends StandardAmountInput {
 
 export class SECPTransferInput extends AmountInput {
   protected _typeName = "SECPTransferInput";
-  protected _typeID = AVMConstants.SECPINPUTID;
+  protected _typeID = AVMConstants.SECPXFERINPUTID;
 
   //serialize and deserialize both are inherited
 
@@ -84,7 +84,15 @@ export class SECPTransferInput extends AmountInput {
      * Returns the inputID for this input
      */
   getInputID():number {
-    return AVMConstants.SECPINPUTID;
+    return AVMConstants.SECPXFERINPUTID;
+  }
+
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.SECPXFERINPUTID;
+    } else if (codecID === 1) {
+      return AVMConstants.SECPXFERINPUTID_CODECONE;
+    }
   }
 
   getCredentialID = ():number => AVMConstants.SECPCREDENTIAL;

--- a/src/apis/avm/interfaces.ts
+++ b/src/apis/avm/interfaces.ts
@@ -1,0 +1,26 @@
+/**
+ * @packageDocumentation
+ * @module AVM-Interfaces
+ */
+
+import { UTXOResponse } from "./../../common/interfaces";
+import { UTXOSet } from "./../../apis/avm";
+
+export interface iUTXOID {
+  txID:string
+  outputIndex:number
+}
+
+export interface iGetBalanceResponse {
+  balance:string
+  utxoIDs:iUTXOID[] 
+}
+
+export interface iGetBalanceParams {
+  address:string
+  assetID:string
+}
+
+export interface iAVMUTXOResponse extends UTXOResponse {
+  utxos: UTXOSet
+}

--- a/src/apis/avm/operationtx.ts
+++ b/src/apis/avm/operationtx.ts
@@ -81,12 +81,12 @@ export class OperationTx extends BaseTx {
   /**
    * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[OperationTx]].
    */
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
       this.numOps.writeUInt32BE(this.ops.length, 0);
-      let barr:Array<Buffer> = [super.toBuffer(), this.numOps];
+      let barr:Array<Buffer> = [super.toBuffer(codecID), this.numOps];
       this.ops = this.ops.sort(TransferableOperation.comparator());
       for(let i = 0; i < this.ops.length; i++) {
-          barr.push(this.ops[i].toBuffer());
+          barr.push(this.ops[i].toBuffer(codecID));
       }
       return Buffer.concat(barr);
   }

--- a/src/apis/avm/ops.ts
+++ b/src/apis/avm/ops.ts
@@ -335,7 +335,7 @@ export class SECPMintOperation extends Operation {
   /**
    * Returns the buffer representing the [[SECPMintOperation]] instance.
    */
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     let superbuff:Buffer = super.toBuffer();
     let mintoutBuff:Buffer = this.mintOutput.toBuffer();
     let transferOutBuff:Buffer = this.transferOutput.toBuffer();

--- a/src/apis/avm/ops.ts
+++ b/src/apis/avm/ops.ts
@@ -23,11 +23,11 @@ const serializer = Serialization.getInstance();
  * @returns An instance of an [[Operation]]-extended class.
  */
 export const SelectOperationClass = (opid:number, ...args:Array<any>):Operation => {
-    if(opid == AVMConstants.SECPMINTOPID) {
+    if(opid === AVMConstants.SECPMINTOPID || opid === AVMConstants.SECPMINTOPID_CODECONE) {
       return new SECPMintOperation(...args);
-    } else if(opid == AVMConstants.NFTMINTOPID){
+    } else if(opid === AVMConstants.NFTMINTOPID || opid === AVMConstants.NFTMINTOPID_CODECONE){
       return new NFTMintOperation(...args);
-    } else if(opid == AVMConstants.NFTXFEROPID){
+    } else if(opid === AVMConstants.NFTXFEROPID || opid === AVMConstants.NFTXFEROPID_CODECONE){
       return new NFTTransferOperation(...args);
     }
     /* istanbul ignore next */
@@ -40,6 +40,7 @@ export const SelectOperationClass = (opid:number, ...args:Array<any>):Operation 
 export abstract class Operation extends Serializable{
   protected _typeName = "Operation";
   protected _typeID = undefined;
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number | void {};
 
   serialize(encoding:SerializedEncoding = "hex"):object {
     let fields:object = super.serialize(encoding);
@@ -212,7 +213,7 @@ export class TransferableOperation extends Serializable {
     return this.operation.fromBuffer(bytes, offset);
   }
 
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     const numutxoIDs = Buffer.alloc(4);
     numutxoIDs.writeUInt32BE(this.utxoIDs.length, 0);
     let bsize:number = this.assetid.length + numutxoIDs.length;
@@ -224,7 +225,7 @@ export class TransferableOperation extends Serializable {
       bsize += b.length;
     }
     const opid:Buffer = Buffer.alloc(4);
-    opid.writeUInt32BE(this.operation.getOperationID(), 0);
+    opid.writeUInt32BE(this.operation.getEncodingID(codecID) as number, 0);
     barr.push(opid);
     bsize += opid.length;
     const b:Buffer = this.operation.toBuffer();
@@ -288,6 +289,14 @@ export class SECPMintOperation extends Operation {
    */
   getOperationID():number {
     return this._typeID;
+  }
+
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.SECPMINTOPID;
+    } else if (codecID === 1) {
+      return AVMConstants.SECPMINTOPID_CODECONE;
+    }
   }
 
   /**
@@ -389,8 +398,6 @@ export class NFTMintOperation extends Operation {
     });
   }
 
-
-
   protected groupID:Buffer = Buffer.alloc(4);
   protected payload:Buffer;
   protected outputOwners:Array<OutputOwners> = [];
@@ -400,6 +407,14 @@ export class NFTMintOperation extends Operation {
    */
   getOperationID():number {
     return this._typeID;
+  }
+
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.NFTMINTOPID;
+    } else if (codecID === 1) {
+      return AVMConstants.NFTMINTOPID_CODECONE;
+    }
   }
 
   /**
@@ -540,6 +555,14 @@ export class NFTTransferOperation extends Operation {
    */
   getOperationID():number {
     return this._typeID;
+  }
+
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.NFTXFEROPID;
+    } else if (codecID === 1) {
+      return AVMConstants.NFTXFEROPID_CODECONE;
+    }
   }
 
   /**

--- a/src/apis/avm/outputs.ts
+++ b/src/apis/avm/outputs.ts
@@ -194,6 +194,14 @@ export class NFTMintOutput extends NFTOutput {
       return this._typeID;
   }
 
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.NFTMINTOUTPUTID;
+    } else if (codecID === 1) {
+      return AVMConstants.NFTMINTOUTPUTID_CODECONE;
+    }
+  }
+
   /**
    * Popuates the instance from a {@link https://github.com/feross/buffer|Buffer} representing the [[NFTMintOutput]] and returns the size of the output.
    */
@@ -270,11 +278,18 @@ export class NFTTransferOutput extends NFTOutput {
       return this._typeID;
   }
 
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.NFTXFEROUTPUTID;
+    } else if (codecID === 1) {
+      return AVMConstants.NFTXFEROUTPUTID_CODECONE;
+    }
+  }
+
   /**
    * Returns the payload as a {@link https://github.com/feross/buffer|Buffer} with content only.
    */
   getPayload = ():Buffer =>  bintools.copyFrom(this.payload);
-
 
   /**
    * Returns the payload as a {@link https://github.com/feross/buffer|Buffer} with length of payload prepended.

--- a/src/apis/avm/outputs.ts
+++ b/src/apis/avm/outputs.ts
@@ -20,13 +20,13 @@ const serializer = Serialization.getInstance();
  * @returns An instance of an [[Output]]-extended class.
  */
 export const SelectOutputClass = (outputid:number, ...args:Array<any>):Output => {
-    if(outputid == AVMConstants.SECPXFEROUTPUTID){
+    if(outputid === AVMConstants.SECPXFEROUTPUTID || outputid === AVMConstants.SECPXFEROUTPUTID_CODECONE){
         return new SECPTransferOutput( ...args);
-    } else if(outputid == AVMConstants.SECPMINTOUTPUTID){
+    } else if(outputid === AVMConstants.SECPMINTOUTPUTID || outputid === AVMConstants.SECPMINTOUTPUTID_CODECONE){
         return new SECPMintOutput( ...args);
-    } else if(outputid == AVMConstants.NFTMINTOUTPUTID){
+    } else if(outputid === AVMConstants.NFTMINTOUTPUTID){
         return new NFTMintOutput(...args);
-    } else if(outputid == AVMConstants.NFTXFEROUTPUTID){
+    } else if(outputid === AVMConstants.NFTXFEROUTPUTID){
         return new NFTTransferOutput(...args);
     }
     throw new Error("Error - SelectOutputClass: unknown outputid " + outputid);
@@ -110,6 +110,14 @@ export class SECPTransferOutput extends AmountOutput {
     return this._typeID;
   }
 
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.SECPXFEROUTPUTID;
+    } else if (codecID === 1) {
+      return AVMConstants.SECPXFEROUTPUTID_CODECONE;
+    }
+  }
+
   create(...args:any[]):this{
     return new SECPTransferOutput(...args) as this;
   }
@@ -136,6 +144,14 @@ export class SECPMintOutput extends Output {
    */
   getOutputID():number {
     return this._typeID;
+  }
+
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number {
+    if(codecID === 0) {
+      return AVMConstants.SECPMINTOUTPUTID;
+    } else if (codecID === 1) {
+      return AVMConstants.SECPMINTOUTPUTID_CODECONE;
+    }
   }
 
   /**

--- a/src/apis/avm/tx.ts
+++ b/src/apis/avm/tx.ts
@@ -50,6 +50,8 @@ export const SelectTxClass = (txtype:number, ...args:Array<any>):BaseTx => {
 export class UnsignedTx extends StandardUnsignedTx<KeyPair, KeyChain, BaseTx> {
   protected _typeName = "UnsignedTx";
   protected _typeID = undefined;
+  // TODO - Uncomment to set codecid
+  // protected codecid = 1;
 
   //serialize is inherited
 

--- a/src/apis/avm/tx.ts
+++ b/src/apis/avm/tx.ts
@@ -81,8 +81,8 @@ export class UnsignedTx extends StandardUnsignedTx<KeyPair, KeyChain, BaseTx> {
    *
    * @returns A signed [[StandardTx]]
    */
-  sign(kc:KeyChain):Tx {
-    const txbuff = this.toBuffer();
+  sign(kc:KeyChain, codecID:number = AVMConstants.LATESTCODEC):Tx {
+    const txbuff = this.toBuffer(codecID);
     const msg:Buffer = Buffer.from(createHash('sha256').update(txbuff).digest());
     const sigs:Array<Credential> = this.transaction.sign(msg, kc);
     return new Tx(this, sigs);

--- a/src/common/credentials.ts
+++ b/src/common/credentials.ts
@@ -6,6 +6,7 @@ import { NBytes } from './nbytes';
 import { Buffer } from 'buffer/';
 import BinTools from '../utils/bintools';
 import { Serializable, Serialization, SerializedEncoding } from '../utils/serialization';
+import { AVMConstants } from '../apis/avm';
 
 
 /**
@@ -101,6 +102,7 @@ export class Signature extends NBytes {
 export abstract class Credential extends Serializable{
   protected _typeName = "Credential";
   protected _typeID = undefined;
+  getEncodingID(codecID:number = AVMConstants.LATESTCODEC): number | void {};
 
   serialize(encoding:SerializedEncoding = "hex"):object {
     let fields:object = super.serialize(encoding);

--- a/src/common/input.ts
+++ b/src/common/input.ts
@@ -7,6 +7,7 @@ import BinTools from '../utils/bintools';
 import BN from 'bn.js';
 import { SigIdx } from './credentials';
 import { Serializable, Serialization, SerializedEncoding } from '../utils/serialization';
+import { AVMConstants } from '../../src/apis/avm/constants';
 
 /**
  * @ignore
@@ -17,6 +18,7 @@ const serializer = Serialization.getInstance();
 export abstract class Input extends Serializable {
   protected _typeName = "Input";
   protected _typeID = undefined;
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number | void {};
 
   serialize(encoding:SerializedEncoding = "hex"):object {
     let fields:object = super.serialize(encoding);
@@ -147,10 +149,10 @@ export abstract class StandardParseableInput extends Serializable {
   // must be implemented to select input types for the VM in question
   abstract fromBuffer(bytes:Buffer, offset?:number):number; 
 
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     const inbuff:Buffer = this.input.toBuffer();
     const inid:Buffer = Buffer.alloc(4);
-    inid.writeUInt32BE(this.input.getInputID(), 0);
+    inid.writeUInt32BE(this.input.getEncodingID(codecID) as number, 0);
     const barr:Array<Buffer> = [inid, inbuff];
     return Buffer.concat(barr, inid.length + inbuff.length);
   }
@@ -227,8 +229,8 @@ export abstract class StandardTransferableInput extends StandardParseableInput{
   /**
    * Returns a {@link https://github.com/feross/buffer|Buffer} representation of the [[StandardTransferableInput]].
    */
-  toBuffer():Buffer {
-    const parseableBuff:Buffer = super.toBuffer();
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
+    const parseableBuff:Buffer = super.toBuffer(codecID);
     const bsize:number = this.txid.length + this.outputidx.length + this.assetid.length + parseableBuff.length;
     const barr:Array<Buffer> = [this.txid, this.outputidx, this.assetid, parseableBuff];
     const buff: Buffer = Buffer.concat(barr, bsize);

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -19,10 +19,6 @@ export interface UTXOResponse {
   endIndex: Index
 }
 
-export interface AVMUTXOResponse extends UTXOResponse {
-  utxos: AVMUTXOSet
-}
-
 export interface PlatformVMUTXOResponse extends UTXOResponse {
   utxos: PlatformVMUTXOSet
 }

--- a/src/common/output.ts
+++ b/src/common/output.ts
@@ -9,6 +9,7 @@ import BinTools from '../utils/bintools';
 import { NBytes } from './nbytes';
 import { UnixNow } from '../utils/helperfunctions';
 import { Serializable, Serialization, SerializedEncoding } from '../utils/serialization';
+import { AVMConstants } from '../../src/apis/avm/constants';
 
 /**
  * @ignore
@@ -307,6 +308,7 @@ export class OutputOwners extends Serializable {
 export abstract class Output extends OutputOwners {
   protected _typeName = "Output";
   protected _typeID = undefined;
+  getEncodingID(codecID: number = AVMConstants.LATESTCODEC): number | void {};
   
   //serialize and deserialize both are inherited
 
@@ -314,7 +316,7 @@ export abstract class Output extends OutputOwners {
    * Returns the outputID for the output which tells parsers what type it is
    */
   abstract getOutputID():number;
-
+ 
   abstract clone():this;
 
   abstract create(...args:any[]):this;
@@ -358,10 +360,10 @@ export abstract class StandardParseableOutput extends Serializable {
   // must be implemented to select output types for the VM in question
   abstract fromBuffer(bytes:Buffer, offset?:number):number; 
 
-  toBuffer():Buffer {
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     const outbuff:Buffer = this.output.toBuffer();
     const outid:Buffer = Buffer.alloc(4);
-    outid.writeUInt32BE(this.output.getOutputID(), 0);
+    outid.writeUInt32BE(this.output.getEncodingID(codecID) as number, 0);
     const barr:Array<Buffer> = [outid, outbuff];
     return Buffer.concat(barr, outid.length + outbuff.length);
   }
@@ -402,8 +404,8 @@ export abstract class StandardTransferableOutput extends StandardParseableOutput
   // must be implemented to select output types for the VM in question
   abstract fromBuffer(bytes:Buffer, offset?:number):number; 
 
-  toBuffer():Buffer {
-    const parseableBuff:Buffer = super.toBuffer();
+  toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
+    const parseableBuff:Buffer = super.toBuffer(codecID);
     const barr:Array<Buffer> = [this.assetID, parseableBuff];
     return Buffer.concat(barr, this.assetID.length + parseableBuff.length);
   }

--- a/src/common/tx.ts
+++ b/src/common/tx.ts
@@ -52,7 +52,7 @@ export abstract class StandardBaseTx<KPClass extends StandardKeyPair, KCClass ex
   protected outs:Array<StandardTransferableOutput>;
   protected numins:Buffer = Buffer.alloc(4);
   protected ins:Array<StandardTransferableInput>;
-  protected memo:Buffer = Buffer.alloc(4);
+  protected memo:Buffer = Buffer.alloc(0);
 
   /**
    * Returns the id of the [[StandardBaseTx]]
@@ -157,10 +157,7 @@ export abstract class StandardBaseTx<KPClass extends StandardKeyPair, KCClass ex
     super();
     this.networkid.writeUInt32BE(networkid, 0);
     this.blockchainid = blockchainid;
-    if(typeof memo === "undefined"){
-      this.memo = Buffer.alloc(4);
-      this.memo.writeUInt32BE(0,0);
-    } else {
+    if(typeof memo != "undefined"){
       this.memo = memo;
     }
     

--- a/src/common/tx.ts
+++ b/src/common/tx.ts
@@ -269,7 +269,8 @@ SBTx extends StandardBaseTx<KPClass, KCClass>
 
   toBuffer(codecID: number = AVMConstants.LATESTCODEC):Buffer {
     const codecBuf:Buffer = Buffer.alloc(2);
-    codecBuf.writeUInt16BE(this.codecid, 0)
+    codecBuf.writeUInt16BE(codecID, 0)
+    this.codecid = codecID;
     const txtype:Buffer = Buffer.alloc(4);
     if(codecID === 0) {
       // in this case the final result is the same for all tx types in both codec 0 and 1
@@ -277,7 +278,7 @@ SBTx extends StandardBaseTx<KPClass, KCClass>
     } else if (codecID === 1) {
       txtype.writeUInt32BE(this.transaction.getTxType(), 0);
     }
-    const basebuff = this.transaction.toBuffer();
+    const basebuff = this.transaction.toBuffer(codecID);
     return Buffer.concat([codecBuf, txtype, basebuff], codecBuf.length + txtype.length + basebuff.length);
   }
 
@@ -348,7 +349,7 @@ export abstract class StandardTx<
     bsize += credlen.length;
     for (let i = 0; i < this.credentials.length; i++) {
       const credid:Buffer = Buffer.alloc(4);
-      credid.writeUInt32BE(this.credentials[i].getCredentialID(), 0);
+      credid.writeUInt32BE(this.credentials[i].getEncodingID(codecID) as number, 0);
       barr.push(credid);
       bsize += credid.length;
       const credbuff:Buffer = this.credentials[i].toBuffer();

--- a/src/common/tx.ts
+++ b/src/common/tx.ts
@@ -377,8 +377,8 @@ export abstract class StandardTx<
    * @remarks
    * unlike most toStrings, this returns in cb58 serialization format
    */
-  toString():string {
-    return bintools.cb58Encode(this.toBuffer());
+  toString(codecID:number = AVMConstants.LATESTCODEC):string {
+    return bintools.cb58Encode(this.toBuffer(codecID));
   }
 
   /**

--- a/tests/apis/avm/inputs.test.ts
+++ b/tests/apis/avm/inputs.test.ts
@@ -69,7 +69,7 @@ describe('Inputs', () => {
     input = new SECPTransferInput(amount);
     xferinput = new TransferableInput(txid, txidx, asset, input);
     expect(xferinput.getUTXOID()).toBe(u.getUTXOID());
-    expect(input.getInputID()).toBe(AVMConstants.SECPINPUTID);
+    expect(input.getInputID()).toBe(AVMConstants.SECPXFERINPUTID);
 
     input.addSignatureIdx(0, addrs2[0]);
     input.addSignatureIdx(1, addrs2[1]);


### PR DESCRIPTION
## Summary

As part of the Apricot hardfork we need to introduce codecID `00 01` to avalanchejs in a way which is backward compatible w/ codecID `00 00`. 

## Testing Scripts

We need to test building transactions manually as well as using the high level utility methods such as `buildBaseTx`. Also we need to test codecID `00 00` as well as codecID `00 01` and confirm that they're interoperable.

### AVM

Each of these tests will work for both codecID `00 00` and `00 01`. Currently when you run them w/ no changes, other than adding the missing privkey, they default to codecID `00 00` which is the `LATESTCODEC` in the [AVM Constants](https://github.com/ava-labs/avalanchejs/blob/master/src/apis/avm/constants.ts#L7). In all [toBuffer](https://github.com/ava-labs/avalanchejs/blob/codec-01-b/src/common/tx.ts#L95) calls we're also setting the `codecID` parameter's default value to `LATESTCODEC`. This enables us to flip the switch in one place, `AVMConstants.LATESTCODEC`, and update the latest codecID across all of AvalancheJS.

To test codecID `00 00` you simply leave the scripts as they are. `sign` now has an [optional 2nd parameter](https://github.com/ava-labs/avalanchejs/blob/codec-01-b/src/apis/avm/tx.ts#L84) to set the codecID. Both `sign` and `issueTx` will each call `toBuffer` and correctly pass the default codecID. 

```ts
// for codecID 00 00
const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
const tx: Tx = unsignedTx.sign(xKeychain)
const id: string = await xchain.issueTx(tx)
console.log(id)
```

And for codecID `00 01` create a `codecID` variable w/ the value `1` and pass that to `sign` and `tx.toBuffer`. Convert the tx buffer to a cb58 encoded string and pass that to `issueTx`.

```ts
// for codecID 00 01
const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
const codecID: number = 1
const tx: Tx = unsignedTx.sign(xKeychain, codecID)
const cb58EncodedTx: string = bintools.cb58Encode(tx.toBuffer(codecID))
const id: string = await xchain.issueTx(cb58EncodedTx)
console.log(id)
```

Each of the tests have the needed code for testing against both codecIDs at the bottom. Look for and comment/uncomment the following lines as needed.

```ts
// start uncomment for codecID 00 00
// stop uncomment for codecID 00 00
// start uncomment for codecID 00 01
// stop uncomment for codecID 00 01
```

#### Manual

Send AVAX in a `BaseTx`

* [avm-baseTx-avax](https://gist.github.com/cgcardona/06bb073dc0a8e865e5b773aa98652d42)

Send AVAX and ANT in a `BaseTx`

* [avm-baseTx-ant](https://gist.github.com/cgcardona/5a193aa415a67dcfe76fa43d702937ab)

Create an ANT

* [avm-createAssetTx-ant](https://gist.github.com/cgcardona/1ffa78db93ccd36825815751289a9484)

Create an NFT

* [avm-createAssetTx-nft](https://gist.github.com/cgcardona/b2a3cb899055444a0a512524c8afe372)

Mint an ANT

* [avm-operationTx-mint-ant](https://gist.github.com/cgcardona/b8e2bd0e038974ef19eea4a90f230ec3)

Mint an NFT

* [avm-operationTx-mint-nft](https://gist.github.com/cgcardona/7d9caf6bb0fb1a5d3a434890dc95ce8a)

Export AVAX from the X-Chain to the C-Chain or P-Chain

* [avm-exportTx-avax](https://gist.github.com/cgcardona/fad3be6c4829dc17f5216da6c82fdf51)

Export AVAX and ANT from the X-Chain to the C-Chain

* [avm-exportTx-ant](https://gist.github.com/cgcardona/3073e4c9c4e0aa0fad59fc7c0b3c1132)

Import AVAX from the C-Chain or the P-Chain to the X-Chain

* [avm-importTx-avax](https://gist.github.com/cgcardona/9916645b3ca25d47193b95a03dcc08d5)

Import AVAX and ANT from the C-Chain

* [avm-importTx-ant](https://gist.github.com/cgcardona/4061e9c4981696aa1b15acdfc4c04fef)

Still need to transfer NFTs.

#### High Level Utility Methods

Send AVAX in a `BaseTx`

* [avm-buildBaseTx-avax](https://gist.github.com/cgcardona/a7c7d3f8ba58eeafa9a7de908f288280)

Create an ANT

* [avm-buildCreateAssetTx-ant](https://gist.github.com/cgcardona/f927ba1705cc8794701f5d4c410deace)

Create an NFT

* [avm-buildCreateNFTAssetTx-nft](https://gist.github.com/cgcardona/29bf3869f046538b263b04f089c813bb)

Mint an ANT

* [avm-buildSECPMintTx-ant](https://gist.github.com/cgcardona/58fd90402cfb1983113cd0328afe5759)

Mint an NFT

* [avm-buildCreateNFTMintTx-nft](https://gist.github.com/cgcardona/f881d52f9d688aff0cdb1e8f862e8782)

Transfer an NFT

* [avm-buildNFTTransferTx-nft](https://gist.github.com/cgcardona/02bb60ecc0031722c9a5767a3631b6fb)

Import AVAX to the X-Chain from the C-Chain or the P-Chain

* [avm-buildImportTx-avax](https://gist.github.com/cgcardona/bae4fe38e7e688cc9933f5da3c52a9b3)

Export AVAX from the X-Chain to the C-Chain or the P-Chain

* [avm-buildExportTx-avax](https://gist.github.com/cgcardona/dff91dc66cf9ff2ebff6526294c7be96)

### EVM

#### Manual

* [evm-importTx-avax](https://gist.github.com/cgcardona/53a68e11957dd6fdbd0f77aaec0e5706)
* [evm-exportTx-avax](https://gist.github.com/cgcardona/006028ecce7b22157179e2eb333d57c9)

#### High Level Utility Methods

* [evm-buildExportTx-avax](https://gist.github.com/cgcardona/4427869819ef24436cba73d90c20214f)

## Miscellaneous

### Add missing Interfaces

Most of our API responses are generic `Promise<object>` which makes it challenging to debug what response to expect in your scripts. Ultimately we need to add interfaces for all of our responses but in this PR we're adding interfaces for any API calls which we're making during adding codecID `00 01` to AvalancheJS.

#### AVM

* `iUTXOID`
* `iGetBalanceResponse`
* `iGetBalanceParams`
* `iAVMUTXOResponse`

### AS-358

[Debug memo of `00 00 00 00`](https://ava-labs.atlassian.net/browse/AS-358)