### PR TITLE
Add optional 4th parameter called `headers` to `JRPCAPI.callMethod`

### DIFF
--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -6,22 +6,35 @@ import BN from 'bn.js';
 import { Buffer } from 'buffer/';
 import AvalancheCore from '../../avalanche';
 import BinTools from '../../utils/bintools';
-import { UTXO, UTXOSet } from './utxos';
+import { 
+  UTXO, 
+  UTXOSet 
+} from './utxos';
 import { AVMConstants } from './constants';
 import { KeyChain } from './keychain';
-import { Tx, UnsignedTx } from './tx';
+import { 
+  Tx, 
+  UnsignedTx 
+} from './tx';
 import { PayloadBase } from '../../utils/payload';
 import { SECPMintOutput } from './outputs';
 import { InitialStates } from './initialstates';
 import { UnixNow } from '../../utils/helperfunctions';
 import { JRPCAPI } from '../../common/jrpcapi';
 import { RequestResponseData } from '../../common/apibase';
-import { Defaults, PrimaryAssetAlias, ONEAVAX } from '../../utils/constants';
+import { 
+  Defaults, 
+  PrimaryAssetAlias, 
+  ONEAVAX 
+} from '../../utils/constants';
 import { MinterSet } from './minterset';
 import { PersistanceOptions } from '../../utils/persistenceoptions';
 import { OutputOwners } from '../../common/output';
 import { SECPTransferOutput } from './outputs';
-import { Index, AVMUTXOResponse } from 'src/common';
+import { 
+  iIndex, 
+  iAVMUTXOResponse 
+} from 'src/common';
 
 /**
  * @ignore
@@ -652,9 +665,9 @@ export class AVMAPI extends JRPCAPI {
     addresses: string[] | string,
     sourceChain: string = undefined,
     limit:number = 0,
-    startIndex: Index = undefined,
+    startIndex: iIndex = undefined,
     persistOpts: PersistanceOptions = undefined
-  ):Promise<AVMUTXOResponse> => {
+  ):Promise<iAVMUTXOResponse> => {
     
     if(typeof addresses === "string") {
       addresses = [addresses];
@@ -874,7 +887,7 @@ export class AVMAPI extends JRPCAPI {
     throw new Error("Error - AVMAPI.buildImportTx: Invalid destinationChain type: " + (typeof sourceChain) );
   }
   
-  const avmUTXOResponse: AVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined)
+  const avmUTXOResponse: iAVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined)
   const atomicUTXOs: UTXOSet = await avmUTXOResponse.utxos;
   const avaxAssetID: Buffer = await this.getAVAXAssetID();
   const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();

--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -25,8 +25,8 @@ import {
 import { EVMConstants } from './constants';
 import { 
   Asset,
-  Index, 
-  EVMUTXOResponse 
+  iIndex, 
+  iEVMUTXOResponse 
 } from './../../common/interfaces'
 import { EVMInput } from './inputs';
 import { 
@@ -306,8 +306,8 @@ export class EVMAPI extends JRPCAPI {
     addresses: string[] | string,
     sourceChain: string = undefined,
     limit: number = 0,
-    startIndex: Index = undefined
-  ): Promise<EVMUTXOResponse> => {
+    startIndex: iIndex = undefined
+  ): Promise<iEVMUTXOResponse> => {
     if(typeof addresses === "string") {
       addresses = [addresses];
     }
@@ -518,7 +518,7 @@ export class EVMAPI extends JRPCAPI {
       // if there is no sourceChain passed in or the sourceChain is any data type other than a Buffer then throw an error
       throw new Error('Error - EVMAPI.buildImportTx: sourceChain is undefined or invalid sourceChain type.');
     }
-    const evmUTXOResponse: EVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
+    const evmUTXOResponse: iEVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
     const atomicUTXOs: UTXOSet = evmUTXOResponse.utxos;
     const avaxAssetID: Buffer = await this.getAVAXAssetID();
     const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -9,14 +9,30 @@ import { JRPCAPI } from '../../common/jrpcapi';
 import { RequestResponseData } from '../../common/apibase';
 import BinTools from '../../utils/bintools';
 import { KeyChain } from './keychain';
-import { Defaults, PlatformChainID, ONEAVAX } from '../../utils/constants';
+import { 
+  Defaults, 
+  PlatformChainID, 
+  ONEAVAX 
+} from '../../utils/constants';
 import { PlatformVMConstants } from './constants';
-import { UnsignedTx, Tx } from './tx';
+import { 
+  UnsignedTx, 
+  Tx 
+} from './tx';
 import { PayloadBase } from '../../utils/payload';
-import { UnixNow, NodeIDStringToBuffer } from '../../utils/helperfunctions';
-import { UTXO, UTXOSet } from './utxos';
+import { 
+  UnixNow, 
+  NodeIDStringToBuffer 
+} from '../../utils/helperfunctions';
+import { 
+  UTXO, 
+  UTXOSet 
+} from './utxos';
 import { PersistanceOptions } from '../../utils/persistenceoptions';
-import { Index, PlatformVMUTXOResponse } from 'src/common';
+import { 
+  iIndex, 
+  iPlatformVMUTXOResponse 
+} from 'src/common';
 
 /**
  * @ignore
@@ -891,9 +907,9 @@ export class PlatformVMAPI extends JRPCAPI {
     addresses: string[] | string,
     sourceChain: string = undefined,
     limit: number = 0,
-    startIndex: Index = undefined,
+    startIndex: iIndex = undefined,
     persistOpts: PersistanceOptions = undefined
-  ): Promise<PlatformVMUTXOResponse> => {
+  ): Promise<iPlatformVMUTXOResponse> => {
     
     if(typeof addresses === "string") {
       addresses = [addresses];
@@ -982,7 +998,7 @@ export class PlatformVMAPI extends JRPCAPI {
       srcChain = bintools.cb58Encode(sourceChain);
       throw new Error("Error - PlatformVMAPI.buildImportTx: Invalid destinationChain type: " + (typeof sourceChain) );
     }
-    const platformVMUTXOResponse: PlatformVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
+    const platformVMUTXOResponse: iPlatformVMUTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
     const atomicUTXOs: UTXOSet = platformVMUTXOResponse.utxos;
     const avaxAssetID: Buffer = await this.getAVAXAssetID();
 

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -8,26 +8,26 @@ import { UTXOSet as AVMUTXOSet } from 'src/apis/avm';
 import { UTXOSet as EVMUTXOSet } from 'src/apis/evm';
 import { UTXOSet as PlatformVMUTXOSet } from 'src/apis/platformvm';
 
-export interface Index {
+export interface iIndex {
   address: string
   utxo: string
 }
 
-export interface UTXOResponse {
+export interface iUTXOResponse {
   numFetched: number
   encoding: string
-  endIndex: Index
+  endIndex: iIndex
 }
 
-export interface AVMUTXOResponse extends UTXOResponse {
+export interface iAVMUTXOResponse extends iUTXOResponse {
   utxos: AVMUTXOSet
 }
 
-export interface PlatformVMUTXOResponse extends UTXOResponse {
+export interface iPlatformVMUTXOResponse extends iUTXOResponse {
   utxos: PlatformVMUTXOSet
 }
 
-export interface EVMUTXOResponse extends UTXOResponse {
+export interface iEVMUTXOResponse extends iUTXOResponse {
   utxos: EVMUTXOSet
 }
 
@@ -37,7 +37,7 @@ export interface Asset {
   assetID: Buffer
   denomination: number
 }
-export interface Payload {
+export interface iPayload {
   result: {
     name: string
     symbol: string

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -39,9 +39,16 @@ export interface Asset {
 }
 export interface Payload {
   result: {
-    name: string,
-    symbol: string,
-    assetID: string,
+    name: string
+    symbol: string
+    assetID: string
     denomination: number
   }
+}
+
+export interface iRPC {
+  id?: number
+  method?: string
+  params?: object[] | object
+  jsonrpc?: string
 }

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -4,15 +4,12 @@
  */
 
 import { AxiosRequestConfig } from 'axios';
-import BinTools from '../utils/bintools';
 import AvalancheCore from '../avalanche';
-import { APIBase, RequestResponseData } from './apibase';
+import { 
+  APIBase, 
+  RequestResponseData 
+} from './apibase';
 import { iRPC } from './interfaces';
-
-/**
- * @ignore
- */
-const bintools = BinTools.getInstance();
 
 export class JRPCAPI extends APIBase {
   protected jrpcVersion:string = '2.0';

--- a/tests/apis/evm/api.test.ts
+++ b/tests/apis/evm/api.test.ts
@@ -4,7 +4,7 @@ import { EVMAPI } from "src/apis/evm/api";
 import BinTools from "src/utils/bintools";
 import * as bech32 from "bech32";
 import createHash from "create-hash";
-import { Payload } from "../../../src/common/interfaces";
+import { iPayload } from "../../../src/common/interfaces";
 import { Defaults } from "src/utils/constants";
 import { 
   Avalanche, 
@@ -92,7 +92,7 @@ describe("EVMAPI", () => {
     const assetIDBuf: Buffer = Buffer.from(createHash("sha256").update(name).digest());
     const assetIDStr: string = bintools.cb58Encode(assetIDBuf);
     const result: Promise<object> = api.getAssetDescription(assetIDStr);
-    const payload: Payload = {
+    const payload: iPayload = {
       result: {
         name: name,
         symbol: symbol,
@@ -102,7 +102,7 @@ describe("EVMAPI", () => {
     };
 
     const responseObj: {
-      data: Payload
+      data: iPayload
     } = {
       data: payload,
     };
@@ -124,9 +124,7 @@ describe("EVMAPI", () => {
     const assetIDBuf: Buffer = Buffer.from(createHash("sha256").update(name).digest());
     const assetIDStr: string = bintools.cb58Encode(assetIDBuf);
     const result: Promise<object> = api.getAssetDescription(assetIDBuf);
-    console.log("========")
-    console.log(result)
-    const payload: Payload = {
+    const payload: iPayload = {
       result: {
         name: name,
         symbol: symbol,
@@ -136,7 +134,7 @@ describe("EVMAPI", () => {
     };
 
     const responseObj: {
-      data: Payload
+      data: iPayload
     } = {
       data: payload,
     };


### PR DESCRIPTION
This PR adds an optional 4th parameter, called `headers`, to the `JRPCAPI`’s  `callMethod` function which enables passing in and setting cookies. `JRPCAPI` is extended by all of the RPC-calling classes. So this change will also enable setting cookies for the `PlatformVM` and the `EVM` as well as the `AVM` and non-VM-specific RPC endpoints such as `Admin`, `Auth`, `Health`, `Info`, `IPC`, `Keystore` and `Metrics`.

Here's a script for testing:

```ts
import { 
  Avalanche
} from "avalanche"
import { 
  AVMAPI, 
} from "avalanche/dist/apis/avm"

const networkID: number = 12345
const ip: string = 'localhost'
const port: number = 9650
const protocol: string = 'http'
const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
const xchain: AVMAPI = avalanche.XChain()

const main = async (): Promise<any> => {
  const allBalances = await xchain.callMethod(
    "avm.getAllBalances", 
    { address: "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u" },
    "ext/bc/X",
    { Cookie: "cookie1=value1; cookie2=value2; cookie3=value3;" } 
  )
  console.log(allBalances.data.result.balances)
}
  
main()
```