### PR TITLE
Fix bug where an empty memo was showing up as a length of 4 bytes of 00s.

### DIFF
--- a/src/common/tx.ts
+++ b/src/common/tx.ts
@@ -6,17 +6,30 @@ import { Buffer } from 'buffer/';
 import BinTools from '../utils/bintools';
 import { Credential } from './credentials';
 import BN from 'bn.js';
-import { StandardKeyChain, StandardKeyPair } from './keychain';
-import { StandardAmountInput, StandardTransferableInput } from './input';
-import { StandardAmountOutput, StandardTransferableOutput } from './output';
+import { 
+  StandardKeyChain, 
+  StandardKeyPair 
+} from './keychain';
+import { 
+  StandardAmountInput, 
+  StandardTransferableInput 
+} from './input';
+import { 
+  StandardAmountOutput, 
+  StandardTransferableOutput 
+} from './output';
 import { DefaultNetworkID } from '../utils/constants';
-import { Serializable, Serialization, SerializedEncoding } from '../utils/serialization';
+import { 
+  Serializable, 
+  Serialization, 
+  SerializedEncoding 
+} from '../utils/serialization';
 
 /**
  * @ignore
  */
-const bintools = BinTools.getInstance();
-const serializer = Serialization.getInstance();
+const bintools: BinTools = BinTools.getInstance();
+const serializer: Serialization = Serialization.getInstance();
 
 /**
  * Class representing a base for all transactions.
@@ -44,14 +57,13 @@ export abstract class StandardBaseTx<KPClass extends StandardKeyPair, KCClass ex
     this.memo = serializer.decoder(fields["memo"], encoding, "hex", "Buffer");
   }
 
-
-  protected networkid:Buffer = Buffer.alloc(4);
-  protected blockchainid:Buffer = Buffer.alloc(32);
-  protected numouts:Buffer = Buffer.alloc(4);
-  protected outs:Array<StandardTransferableOutput>;
-  protected numins:Buffer = Buffer.alloc(4);
-  protected ins:Array<StandardTransferableInput>;
-  protected memo:Buffer = Buffer.alloc(4);
+  protected networkid: Buffer = Buffer.alloc(4);
+  protected blockchainid: Buffer = Buffer.alloc(32);
+  protected numouts: Buffer = Buffer.alloc(4);
+  protected outs: StandardTransferableOutput[];
+  protected numins: Buffer = Buffer.alloc(4);
+  protected ins: StandardTransferableInput[];
+  protected memo: Buffer = Buffer.alloc(0);
 
   /**
    * Returns the id of the [[StandardBaseTx]]
@@ -156,10 +168,7 @@ export abstract class StandardBaseTx<KPClass extends StandardKeyPair, KCClass ex
     super();
     this.networkid.writeUInt32BE(networkid, 0);
     this.blockchainid = blockchainid;
-    if(typeof memo === "undefined"){
-      this.memo = Buffer.alloc(4);
-      this.memo.writeUInt32BE(0,0);
-    } else {
+    if(typeof memo != "undefined"){
       this.memo = memo;
     }
     


### PR DESCRIPTION
There is a bug where an empty memo is being encoded as:

* memo length: `00 00 00 04`
* memo: `00 00 00 00`

An empty memo should be encoded as:

* memo length: `00 00 00 00`
* memo: n/a

This PR resolves that bug.

[More info in AS-358](https://ava-labs.atlassian.net/browse/AS-358). Here is a script for testing. **NOTE** the line:

```ts
  console.log(baseTx.getMemo())
  // <Buffer >
```

It logs a `Buffer` of length 0, which is the correct behavior.

```ts
import { 
  Avalanche,
  BinTools,
  BN,
  Buffer
} from "avalanche"
import {
  AVMAPI, 
  KeyChain as AVMKeyChain,
  SECPTransferOutput,
  SECPTransferInput,
  TransferableOutput,
  TransferableInput,
  UTXOSet,
  UTXO,
  AmountOutput,
  UnsignedTx,
  Tx,
  BaseTx
} from "avalanche/dist/apis/avm"
import { 
  iAVMUTXOResponse 
} from "avalanche/dist/apis/avm/interfaces"
import { Defaults } from "avalanche/dist/utils"
    
const ip: string = "localhost"
const port: number = 9650
const protocol: string = "http"
const networkID: number = 12345
const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
const xchain: AVMAPI = avalanche.XChain()
const bintools: BinTools = BinTools.getInstance()
const xKeychain: AVMKeyChain = xchain.keyChain()
const privKey: string = "PrivateKey-"
xKeychain.importKey(privKey)
const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
const blockchainid: string = Defaults.network['12345'].X.blockchainID
const outputs: TransferableOutput[] = []
const inputs: TransferableInput[] = []
const fee: BN = xchain.getDefaultTxFee()
const threshold: number = 1
const locktime: BN = new BN(0)
    
const main = async (): Promise<any> => {
  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
  const balance: BN = new BN(getBalanceResponse['balance'])
  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
  outputs.push(transferableOutput)

  const avmUTXOResponse: iAVMUTXOResponse = await xchain.getUTXOs(xAddressStrings)
  const utxoSet: UTXOSet = avmUTXOResponse.utxos
  const utxos: UTXO[] = utxoSet.getAllUTXOs()
  utxos.forEach((utxo: UTXO) => {
    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
    const amt: BN = amountOutput.getAmount().clone()
    const txid: Buffer = utxo.getTxID()
    const outputidx: Buffer = utxo.getOutputIdx()

    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
    secpTransferInput.addSignatureIdx(0, xAddresses[0])

    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
    inputs.push(input)
  })

  const baseTx: BaseTx = new BaseTx (
    networkID,
    bintools.cb58Decode(blockchainid),
    outputs,
    inputs
  )
  console.log(baseTx.getMemo())
  // <Buffer >
  const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
  const tx: Tx = unsignedTx.sign(xKeychain)
  const id: string = await xchain.issueTx(tx)
  console.log(id)
}
  
main()
```