### PR TITLE
add admin.getChainAliases method

### DIFF
--- a/examples/admin/getChainAliases.ts
+++ b/examples/admin/getChainAliases.ts
@@ -1,0 +1,19 @@
+import {
+  Avalanche
+} from "../../dist";
+import { AdminAPI } from "../../dist/apis/admin";
+
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const admin: AdminAPI = avalanche.Admin();
+
+const main = async (): Promise<any> => {
+  const blockchain: string = "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed";
+  const aliases: string[] = await admin.getChainAliases(blockchain);
+  console.log(aliases);
+}
+
+main()

--- a/src/apis/admin/api.ts
+++ b/src/apis/admin/api.ts
@@ -56,6 +56,21 @@ export class AdminAPI extends JRPCAPI {
   };
 
   /**
+   * Get all aliases for given blockchain
+   *
+   * @param chain The blockchain’s ID
+   *
+   * @returns Returns a Promise<string[]> containing aliases of the blockchain.
+   */
+  getChainAliases = async (chain:string):Promise<string[]> => {
+    const params:any = {
+      chain,
+    };
+    return this.callMethod('admin.getChainAliases', params)
+      .then((response:RequestResponseData) => response.data.result.aliases);
+  };
+
+  /**
      * Dump the mutex statistics of the node to the specified file.
      *
      * @returns Promise for a boolean that is true on success.

--- a/tests/apis/admin/api.test.ts
+++ b/tests/apis/admin/api.test.ts
@@ -62,6 +62,29 @@ describe('Admin', () => {
     expect(response).toBe(true);
   });
 
+  test('getChainAliases', async () => {
+    const ch:string = 'chain';
+    const result:Promise<string[]> = admin.getChainAliases(ch);
+    const payload:object = {
+      result: {
+        aliases: [
+            "alias1",
+            "alias2"
+        ],
+      },
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response:string[] = await result;
+
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    // @ts-ignore
+    expect(response).toBe(payload.result.aliases);
+  });
+
   test('lockProfile', async () => {
     const result:Promise<boolean> = admin.lockProfile();
     const payload:object = {


### PR DESCRIPTION
with the new update, `admin.getChainAliases` is usable now so I wanted to pr.