### PR TITLE
fix: use `ripemd160` instead of `rmd160` as algorithm descriptor

### DIFF
--- a/src/common/secp256k1.ts
+++ b/src/common/secp256k1.ts
@@ -111,7 +111,7 @@ export abstract class SECP256k1KeyPair extends StandardKeyPair {
         }
         if (pubk.length === 33) {
           const sha256:Buffer = Buffer.from(createHash('sha256').update(pubk).digest());
-          const ripesha:Buffer = Buffer.from(createHash('rmd160').update(sha256).digest());
+          const ripesha:Buffer = Buffer.from(createHash('ripemd160').update(sha256).digest());
           return ripesha;
         }
         /* istanbul ignore next */


### PR DESCRIPTION
https://github.com/crypto-browserify/createHash supports both the `rmd160` and `ripemd160` descriptor for the algorithm that should be used but node.js `require("crypto").createHash` only supports `ripemd160` as the descriptor for this specific algorithm so you will run into an exception of `Digest not supported` in certain environments.