### PR TITLE
v3.2.1

### DIFF
--- a/src/common/secp256k1.ts
+++ b/src/common/secp256k1.ts
@@ -111,7 +111,7 @@ export abstract class SECP256k1KeyPair extends StandardKeyPair {
         }
         if (pubk.length === 33) {
           const sha256:Buffer = Buffer.from(createHash('sha256').update(pubk).digest());
-          const ripesha:Buffer = Buffer.from(createHash('rmd160').update(sha256).digest());
+          const ripesha:Buffer = Buffer.from(createHash('ripemd160').update(sha256).digest());
           return ripesha;
         }
         /* istanbul ignore next */


### PR DESCRIPTION
* [Use `ripemd160` instead of `rmd160` as algorithm descriptor](https://github.com/ava-labs/avalanchejs/pull/155)
