### PR TITLE
Allow setting custom HTTP headers for requests

### DIFF
--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -30,6 +30,8 @@ export default class AvalancheCore {
 
   protected auth:string = undefined;
 
+  protected headers:{ [k: string]: string } = {};
+
   protected apis:{ [k: string]: APIBase } = {};
 
   /**
@@ -68,6 +70,11 @@ export default class AvalancheCore {
   getURL = ():string => this.url;
 
   /**
+   * Returns the custom headers
+   */
+  getHeaders = ():object => this.headers;
+
+  /**
      * Returns the networkID;
      */
   getNetworkID = ():number => this.networkID;
@@ -97,8 +104,18 @@ export default class AvalancheCore {
   };
 
   /**
+   * Adds a new custom header to be included with all requests.
+   *
+   * @param key Header name
+   * @param value Header value
+   */
+  setHeader = (key:string,value:string):void => {
+    this.headers[key] = value
+  }
+
+  /**
    * Sets the temporary auth token used for communicating with the node.
-   * 
+   *
    * @param auth A temporary token provided by the node enabling access to the endpoints on the node.
    */
   setAuthToken = (auth:string):void => {
@@ -106,6 +123,12 @@ export default class AvalancheCore {
   }
 
   protected _setHeaders = (headers:object):object => {
+    if (typeof this.headers === "object") {
+      for (const [key, value] of Object.entries(this.headers)) {
+        headers[key] = value;
+      }
+    }
+
     if(typeof this.auth === "string"){
       headers["Authorization"] = "Bearer " + this.auth;
     }

--- a/tests/avalanche.test.ts
+++ b/tests/avalanche.test.ts
@@ -32,6 +32,7 @@ describe('Avalanche', () => {
         expect(avalanche.getProtocol()).toBe(protocol);
         expect(avalanche.getURL()).toBe(`${protocol}://${ip}:${port}`);
         expect(avalanche.getNetworkID()).toBe(12345);
+        expect(avalanche.getHeaders()).toStrictEqual({});
         avalanche.setNetworkID(50);
         expect(avalanche.getNetworkID()).toBe(50);
         avalanche.setNetworkID(12345);
@@ -79,6 +80,12 @@ describe('Avalanche', () => {
         expect(avalanche.api("keystore2").getDB()).toHaveProperty("namespace");
     });
 
+    test("Customize headers", () => {
+      avalanche.setHeader("X-Custom-Header", "example");
+      expect(avalanche.getHeaders()).toStrictEqual({
+        "X-Custom-Header": "example"
+      });
+    });
 });
 
 describe('HTTP Operations', () => {


### PR DESCRIPTION
This change relates to one of the points in the https://github.com/ava-labs/avalanchejs/issues/156 issue. 

After looking around in the codebase, it seems that only `Authorization` header is allowed. However, when Avalanche node is running behind an API gateway (or a reverse proxy) there might be a different set of HTTP headers used, like `X-Auth-Token` for example.

Update usage:

```node
const client = new Avalanche(....)
client.setHeader("X-Auth-Token", "...")
client.setHeader("Authorization", "token") // <- case where authorization header contains only the token value
```

Any thoughts on merging this in?