### PR TITLE
Add an optional 4th parameter, called `headers`, to the `JRPCAPI`’s  `callMethod` function which enables passing in and setting cookies. 

### DIFF
--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -18,9 +18,12 @@ export class JRPCAPI extends APIBase {
 
   protected rpcid = 1;
 
-  callMethod = async (method:string,
+  callMethod = async (
+    method:string,
     params?:Array<object> | object,
-    baseurl?:string):Promise<RequestResponseData> => {
+    baseurl?:string,
+    headers?: object
+    ):Promise<RequestResponseData> => {
     const ep = baseurl || this.baseurl;
     const rpc:any = {};
     rpc.id = this.rpcid;
@@ -37,14 +40,17 @@ export class JRPCAPI extends APIBase {
       rpc.jsonrpc = this.jrpcVersion;
     }
 
-    const headers:object = { 'Content-Type': 'application/json;charset=UTF-8' };
+    let headrs:object = { 'Content-Type': 'application/json;charset=UTF-8' };
+    if(headers) {
+      headrs = {...headrs, ...headers};
+    }
 
     const axConf:AxiosRequestConfig = {
       baseURL: `${this.core.getProtocol()}://${this.core.getIP()}:${this.core.getPort()}`,
       responseType: 'json',
     };
 
-    return this.core.post(ep, {}, JSON.stringify(rpc), headers, axConf)
+    return this.core.post(ep, {}, JSON.stringify(rpc), headrs, axConf)
       .then((resp:RequestResponseData) => {
         if (resp.status >= 200 && resp.status < 300) {
           this.rpcid += 1;


### PR DESCRIPTION
This PR adds an optional 4th parameter, called `headers`, to the `JRPCAPI`’s  `callMethod` function which enables passing in and setting cookies. `JRPCAPI` is extended by all of the RPC-calling classes. So this change will also enable setting cookies for the `PlatformVM` and the `EVM` as well as the `AVM` and non-VM-specific RPC endpoints such as `Admin`, `Auth`, `Health`, `Info`, `IPC`, `Keystore` and `Metrics`.

Here's a script for testing:

```ts
import { 
  Avalanche
} from "avalanche"
import { 
  AVMAPI, 
} from "avalanche/dist/apis/avm"

const networkID: number = 12345
const ip: string = 'localhost'
const port: number = 9650
const protocol: string = 'http'
const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
const xchain: AVMAPI = avalanche.XChain()

const main = async (): Promise<any> => {
  const allBalances = await xchain.callMethod(
    "avm.getAllBalances", 
    { address: "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u" },
    "ext/bc/X",
    { Cookie: "cookie1=value1; cookie2=value2; cookie3=value3;" } 
  )
  console.log(allBalances.data.result.balances)
}
  
main()
```