### PR TITLE
Parse numFetched from string to number.

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -933,6 +933,7 @@ export class PlatformVMAPI extends JRPCAPI {
       }
       utxos.addArray(data, false);
       response.data.result.utxos = utxos;
+      response.data.result.numFetched = parseInt(response.data.result.numFetched)
       return response.data.result;
     });
   };


### PR DESCRIPTION
Prior to change

```json
numFetched: '2',
```

After change

```json
numFetched: 2,
```

This addresses https://github.com/ava-labs/avalanchejs/issues/128