### PR TITLE
Allow Avalanche initialization w/out port

### DIFF
--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -46,7 +46,11 @@ export default class AvalancheCore {
     this.ip = ip;
     this.port = port;
     this.protocol = protocol;
-    this.url = `${protocol}://${ip}:${port}`;
+    let url : string = `${protocol}://${ip}`;
+    if(port != undefined && typeof port === 'number' && port >= 0) {
+      url = `${url}:${port}`;
+    }
+    this.url = url;
   };
 
   /**

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -45,8 +45,14 @@ export class JRPCAPI extends APIBase {
       headrs = {...headrs, ...headers};
     }
 
+    let baseURL: string = `${this.core.getProtocol()}://${this.core.getIP()}`;
+    const port: number = this.core.getPort();
+    if(port != undefined && typeof port === 'number' && port >= 0) {
+      baseURL = `${baseURL}:${this.core.getPort()}`;
+    }
+
     const axConf:AxiosRequestConfig = {
-      baseURL: `${this.core.getProtocol()}://${this.core.getIP()}:${this.core.getPort()}`,
+      baseURL: baseURL,
       responseType: 'json',
     };
 

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -48,7 +48,7 @@ export class JRPCAPI extends APIBase {
     let baseURL: string = `${this.core.getProtocol()}://${this.core.getIP()}`;
     const port: number = this.core.getPort();
     if(port != undefined && typeof port === 'number' && port >= 0) {
-      baseURL = `${baseURL}:${this.core.getPort()}`;
+      baseURL = `${baseURL}:${port}`;
     }
 
     const axConf:AxiosRequestConfig = {

--- a/tests/avalanche.test.ts
+++ b/tests/avalanche.test.ts
@@ -17,7 +17,7 @@ describe('Avalanche', () => {
     const protocol = "https";
     let avalanche:Avalanche;
     beforeAll(() => {
-        avalanche = new Avalanche(ip,port,protocol, 12345, undefined, undefined, undefined, true);
+        avalanche = new Avalanche(ip, port, protocol, 12345, undefined, undefined, undefined, true);
         avalanche.addAPI("admin", AdminAPI);
         avalanche.addAPI("xchain", AVMAPI, "/ext/subnet/avm", blockchainid)
         avalanche.addAPI("health", HealthAPI);
@@ -26,7 +26,12 @@ describe('Avalanche', () => {
         avalanche.addAPI("metrics", MetricsAPI);
         avalanche.addAPI("pchain", PlatformVMAPI);
     });
-    test('Can initialize', () => {
+    test('Can initialize without port', () => {
+        const a = new Avalanche(ip, undefined, protocol, 12345);
+        expect(a.getPort()).toBe(undefined);
+        expect(a.getURL()).toBe(`${protocol}://${ip}`);
+    });
+    test('Can initialize with port', () => {
         expect(avalanche.getIP()).toBe(ip);
         expect(avalanche.getPort()).toBe(port);
         expect(avalanche.getProtocol()).toBe(protocol);


### PR DESCRIPTION
When querying our full node we need the url to be in this format: `protocol://ip:port`. This is the way AvalancheJS formats requests by default. A recent integration partner, pokt, doesn't have that format.

Here's an example pokt url: `ava-mainnet.gateway.pokt.network/v1/6024004be2161e00218bfa38`. 

The following code, where we pass in `port` will fail w/ a 404. It creates this url format `'/v1/6024534be1261e00308bfa38:443/ext/info'`.

```ts
const ip: string = 'ava-mainnet.gateway.pokt.network/v1/6024004be2161e00218bfa38';
const port: number = 443;
const protocol: string = 'https';
const networkID: number = 1;
const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
const info: InfoAPI = avalanche.Info();
  
const main = async (): Promise<any> => {
  const networkName : string = await info.getNetworkName();
  console.log(networkName);
}
```

If instead we pass in `undefined` when we instantiate `Avalanche` then this PR will create this url format `'/v1/6024534be1261e00308bfa38/ext/info'`

```ts
const ip: string = 'ava-mainnet.gateway.pokt.network/v1/6024534be1261e00308bfa38';
const protocol: string = 'https';
const networkID: number = 1;
const avalanche: Avalanche = new Avalanche(ip, undefined, protocol, networkID);
const info: InfoAPI = avalanche.Info();
  
const main = async (): Promise<any> => {
  const networkName : string = await info.getNetworkName();
  console.log(networkName);
}
```