### PR TITLE
Avoid quoting untrusted inputs. Add example scripts.

### DIFF
--- a/examples/avm/addressFromBuffer.ts
+++ b/examples/avm/addressFromBuffer.ts
@@ -1,0 +1,22 @@
+import { 
+  Avalanche,
+  Buffer
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+
+  const addressBuffer: Buffer = Buffer.from("3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c");
+  const addressString: string = await xchain.addressFromBuffer(addressBuffer);
+  console.log(addressString);
+}
+    
+main()
+  

--- a/examples/avm/createAddress.ts
+++ b/examples/avm/createAddress.ts
@@ -1,0 +1,21 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const username: string = "username";
+  const password: string = "Vz48jjHLTCcAepH95nT4B"
+  const address: string = await xchain.createAddress(username, password);
+  console.log(address);
+}
+    
+main()
+  

--- a/examples/avm/getAVAXAssetID.ts
+++ b/examples/avm/getAVAXAssetID.ts
@@ -1,0 +1,21 @@
+import { 
+  Avalanche,
+  Buffer
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+
+  const assetID: Buffer = await xchain.getAVAXAssetID();
+  console.log(assetID);
+}
+    
+main()
+  

--- a/examples/avm/getAllBalances.ts
+++ b/examples/avm/getAllBalances.ts
@@ -1,0 +1,20 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
+  const balances: object[] = await xchain.getAllBalances(address);
+  console.log(balances);
+}
+    
+main()
+  

--- a/examples/avm/getAssetDescription.ts
+++ b/examples/avm/getAssetDescription.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const assetDescription: any = await xchain.getAssetDescription("AVAX");
+  console.log(assetDescription);
+}
+    
+main()
+  

--- a/examples/avm/getBalance.ts
+++ b/examples/avm/getBalance.ts
@@ -1,0 +1,20 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
+  const balance: object = await xchain.getBalance(address, "AVAX");
+  console.log(balance);
+}
+    
+main()
+  

--- a/examples/avm/getBlockchainAlias.ts
+++ b/examples/avm/getBlockchainAlias.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain()
+  
+const main = async (): Promise<any> => {
+  const alias: string = await xchain.getBlockchainAlias();
+  console.log(alias);
+}
+    
+main()
+  

--- a/examples/avm/getBlockchainID.ts
+++ b/examples/avm/getBlockchainID.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const blockchainID: string = await xchain.getBlockchainID();
+  console.log(blockchainID);
+}
+    
+main()
+  

--- a/examples/avm/getCreationTxFee.ts
+++ b/examples/avm/getCreationTxFee.ts
@@ -1,0 +1,20 @@
+import { 
+  Avalanche,
+  BN
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const txFee: BN = await xchain.getCreationTxFee();
+  console.log(txFee);
+}
+    
+main()
+  

--- a/examples/avm/getDefaultCreationTxFee.ts
+++ b/examples/avm/getDefaultCreationTxFee.ts
@@ -1,0 +1,20 @@
+import { 
+  Avalanche,
+  BN
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const txFee: BN = await xchain.getDefaultCreationTxFee();
+  console.log(txFee);
+}
+    
+main()
+  

--- a/examples/avm/getDefaultTxFee.ts
+++ b/examples/avm/getDefaultTxFee.ts
@@ -1,0 +1,20 @@
+import { 
+  Avalanche,
+  BN
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const defaultTxFee: BN = await xchain.getDefaultTxFee();
+  console.log(defaultTxFee);
+}
+    
+main()
+  

--- a/examples/avm/getTx.ts
+++ b/examples/avm/getTx.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const tx: string = await xchain.getTx("2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D");
+  console.log(tx)
+}
+
+main()
+  

--- a/examples/avm/getTxFee.ts
+++ b/examples/avm/getTxFee.ts
@@ -1,0 +1,20 @@
+import { 
+  Avalanche,
+  BN
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const txFee: BN = await xchain.getTxFee();
+  console.log(txFee);
+}
+    
+main()
+  

--- a/examples/avm/getTxStatus.ts
+++ b/examples/avm/getTxStatus.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const status: string = await xchain.getTxStatus("2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D");
+  console.log(status)
+}
+
+main()
+  

--- a/examples/avm/keyChain.ts
+++ b/examples/avm/keyChain.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI, KeyChain } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const keyChain: KeyChain = await xchain.keyChain();
+  console.log(keyChain);
+}
+    
+main()
+  

--- a/examples/avm/listAddresses.ts
+++ b/examples/avm/listAddresses.ts
@@ -1,0 +1,21 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const username: string = "username";
+  const password: string = "Vz48jjHLTCcAepH95nT4B"
+  const addresses: string[] = await xchain.listAddresses(username, password);
+  console.log(addresses);
+}
+    
+main()
+  

--- a/examples/avm/newKeyChain.ts
+++ b/examples/avm/newKeyChain.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI, KeyChain } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const keyChain: KeyChain = await xchain.newKeyChain();
+  console.log(keyChain);
+}
+    
+main()
+  

--- a/examples/avm/parseAddress.ts
+++ b/examples/avm/parseAddress.ts
@@ -1,0 +1,21 @@
+import { 
+  Avalanche,
+  Buffer
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const addressString: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
+  const addressBuffer: Buffer = await xchain.parseAddress(addressString);
+  console.log(addressBuffer);
+}
+    
+main()
+  

--- a/examples/avm/refreshBlockchainID.ts
+++ b/examples/avm/refreshBlockchainID.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const success: boolean = await xchain.refreshBlockchainID();
+  console.log(success);
+}
+    
+main()
+  

--- a/examples/avm/setAVAXAssetID.ts
+++ b/examples/avm/setAVAXAssetID.ts
@@ -1,0 +1,22 @@
+import { 
+  Avalanche,
+  Buffer
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const newAssetID: string = "11FtAxv";
+  await xchain.setAVAXAssetID(newAssetID);
+  const assetID: Buffer = await xchain.getAVAXAssetID();
+  console.log(assetID);
+}
+    
+main()
+  

--- a/examples/avm/setBlockchainAlias.ts
+++ b/examples/avm/setBlockchainAlias.ts
@@ -1,0 +1,19 @@
+import { 
+  Avalanche
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const newAlias: string = "myXChain";
+  await xchain.setBlockchainAlias(newAlias);
+}
+    
+main()
+  

--- a/examples/avm/setCreationTxFee.ts
+++ b/examples/avm/setCreationTxFee.ts
@@ -1,0 +1,22 @@
+import { 
+  Avalanche,
+  BN
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const fee: BN = new BN(507);
+  await xchain.setCreationTxFee(fee);
+  const txFee: BN = await xchain.getCreationTxFee();
+  console.log(txFee);
+}
+    
+main()
+  

--- a/examples/avm/setTxFee.ts
+++ b/examples/avm/setTxFee.ts
@@ -1,0 +1,22 @@
+import { 
+  Avalanche,
+  BN
+} from "../../dist";
+import { AVMAPI } from "../../dist/apis/avm";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const xchain: AVMAPI = avalanche.XChain();
+  
+const main = async (): Promise<any> => {
+  const fee: BN = new BN(507);
+  await xchain.setTxFee(fee);
+  const txFee: BN = await xchain.getTxFee();
+  console.log(txFee);
+}
+    
+main()
+  

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -51,6 +51,7 @@ export class AVMAPI extends JRPCAPI {
 
   protected creationTxFee:BN = undefined;
 
+
   /**
    * Gets the alias for the blockchainID if it exists, otherwise returns `undefined`.
    *
@@ -272,7 +273,7 @@ export class AVMAPI extends JRPCAPI {
   getBalance = async (address:string, assetID:string):Promise<object> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.getBalance: Invalid address format`);
+      throw new Error("Error - AVMAPI.getBalance: Invalid address format");
     }
     const params:any = {
       address,
@@ -425,7 +426,7 @@ export class AVMAPI extends JRPCAPI {
   exportKey = async (username:string, password:string, address:string):Promise<string> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.exportKey: Invalid address format`);
+      throw new Error("Error - AVMAPI.exportKey: Invalid address format");
     }
     const params:any = {
       username,
@@ -571,7 +572,7 @@ export class AVMAPI extends JRPCAPI {
   getAllBalances = async (address:string):Promise<Array<object>> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.getAllBalances: Invalid address format`);
+      throw new Error("Error - AVMAPI.getAllBalances: Invalid address format");
     }
     const params:any = {
       address,
@@ -1316,7 +1317,7 @@ export class AVMAPI extends JRPCAPI {
 
     if (typeof this.parseAddress(to) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.send: Invalid address format`);
+      throw new Error("Error - AVMAPI.send: Invalid address format");
     }
 
     if (typeof assetID !== 'string') {
@@ -1346,7 +1347,7 @@ export class AVMAPI extends JRPCAPI {
     if (typeof changeAddr !== 'undefined') {
       if(typeof this.parseAddress(changeAddr) === 'undefined') {
         /* istanbul ignore next */
-        throw new Error(`Error - AVMAPI.send: Invalid address format`);
+        throw new Error("Error - AVMAPI.send: Invalid address format");
       }
       params["changeAddr"] = changeAddr;
     } 
@@ -1387,7 +1388,7 @@ export class AVMAPI extends JRPCAPI {
     sendOutputs.forEach((output) => {
       if (typeof this.parseAddress(output.to) === 'undefined') {
         /* istanbul ignore next */
-        throw new Error(`Error - AVMAPI.sendMultiple: Invalid address format`);
+        throw new Error("Error - AVMAPI.sendMultiple: Invalid address format");
       }
       if (typeof output.assetID !== 'string') {
         asset = bintools.cb58Encode(output.assetID);
@@ -1416,7 +1417,7 @@ export class AVMAPI extends JRPCAPI {
     if (typeof changeAddr !== 'undefined') {
       if(typeof this.parseAddress(changeAddr) === 'undefined') {
         /* istanbul ignore next */
-        throw new Error(`Error - AVMAPI.send: Invalid address format`);
+        throw new Error("Error - AVMAPI.send: Invalid address format");
       }
       params["changeAddr"] = changeAddr;
     } 
@@ -1460,7 +1461,7 @@ export class AVMAPI extends JRPCAPI {
         if (typeof addresses[i] === 'string') {
           if (typeof this.parseAddress(addresses[i] as string) === 'undefined') {
             /* istanbul ignore next */
-            throw new Error(`Error - AVMAPI.${caller}: Invalid address format`);
+            throw new Error("Error - AVMAPI.${caller}: Invalid address format");
           }
           addrs.push(addresses[i] as string);
         } else {

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -272,7 +272,7 @@ export class AVMAPI extends JRPCAPI {
   getBalance = async (address:string, assetID:string):Promise<object> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.getBalance: Invalid address format ${address}`);
+      throw new Error(`Error - AVMAPI.getBalance: Invalid address format`);
     }
     const params:any = {
       address,
@@ -425,7 +425,7 @@ export class AVMAPI extends JRPCAPI {
   exportKey = async (username:string, password:string, address:string):Promise<string> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.exportKey: Invalid address format ${address}`);
+      throw new Error(`Error - AVMAPI.exportKey: Invalid address format`);
     }
     const params:any = {
       username,
@@ -571,7 +571,7 @@ export class AVMAPI extends JRPCAPI {
   getAllBalances = async (address:string):Promise<Array<object>> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.getAllBalances: Invalid address format ${address}`);
+      throw new Error(`Error - AVMAPI.getAllBalances: Invalid address format`);
     }
     const params:any = {
       address,
@@ -1316,7 +1316,7 @@ export class AVMAPI extends JRPCAPI {
 
     if (typeof this.parseAddress(to) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - AVMAPI.send: Invalid address format ${to}`);
+      throw new Error(`Error - AVMAPI.send: Invalid address format`);
     }
 
     if (typeof assetID !== 'string') {
@@ -1346,7 +1346,7 @@ export class AVMAPI extends JRPCAPI {
     if (typeof changeAddr !== 'undefined') {
       if(typeof this.parseAddress(changeAddr) === 'undefined') {
         /* istanbul ignore next */
-        throw new Error(`Error - AVMAPI.send: Invalid address format ${changeAddr}`);
+        throw new Error(`Error - AVMAPI.send: Invalid address format`);
       }
       params["changeAddr"] = changeAddr;
     } 
@@ -1387,7 +1387,7 @@ export class AVMAPI extends JRPCAPI {
     sendOutputs.forEach((output) => {
       if (typeof this.parseAddress(output.to) === 'undefined') {
         /* istanbul ignore next */
-        throw new Error(`Error - AVMAPI.sendMultiple: Invalid address format ${output.to}`);
+        throw new Error(`Error - AVMAPI.sendMultiple: Invalid address format`);
       }
       if (typeof output.assetID !== 'string') {
         asset = bintools.cb58Encode(output.assetID);
@@ -1416,7 +1416,7 @@ export class AVMAPI extends JRPCAPI {
     if (typeof changeAddr !== 'undefined') {
       if(typeof this.parseAddress(changeAddr) === 'undefined') {
         /* istanbul ignore next */
-        throw new Error(`Error - AVMAPI.send: Invalid address format ${changeAddr}`);
+        throw new Error(`Error - AVMAPI.send: Invalid address format`);
       }
       params["changeAddr"] = changeAddr;
     } 
@@ -1460,7 +1460,7 @@ export class AVMAPI extends JRPCAPI {
         if (typeof addresses[i] === 'string') {
           if (typeof this.parseAddress(addresses[i] as string) === 'undefined') {
             /* istanbul ignore next */
-            throw new Error(`Error - AVMAPI.${caller}: Invalid address format ${addresses[i]}`);
+            throw new Error(`Error - AVMAPI.${caller}: Invalid address format`);
           }
           addrs.push(addresses[i] as string);
         } else {

--- a/src/apis/avm/basetx.ts
+++ b/src/apis/avm/basetx.ts
@@ -62,7 +62,7 @@ export class BaseTx  extends StandardBaseTx<KeyPair, KeyChain>{
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - BaseTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - BaseTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.BASETX : AVMConstants.BASETX_CODECONE;

--- a/src/apis/avm/basetx.ts
+++ b/src/apis/avm/basetx.ts
@@ -62,7 +62,7 @@ export class BaseTx  extends StandardBaseTx<KeyPair, KeyChain>{
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - BaseTx.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - BaseTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.BASETX : AVMConstants.BASETX_CODECONE;

--- a/src/apis/avm/createassettx.ts
+++ b/src/apis/avm/createassettx.ts
@@ -50,7 +50,7 @@ export class CreateAssetTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - CreateAssetTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - CreateAssetTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.CREATEASSETTX : AVMConstants.CREATEASSETTX_CODECONE;

--- a/src/apis/avm/createassettx.ts
+++ b/src/apis/avm/createassettx.ts
@@ -50,7 +50,7 @@ export class CreateAssetTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - CreateAssetTx.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - CreateAssetTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.CREATEASSETTX : AVMConstants.CREATEASSETTX_CODECONE;

--- a/src/apis/avm/credentials.ts
+++ b/src/apis/avm/credentials.ts
@@ -20,7 +20,7 @@ export const SelectCredentialClass = (credid:number, ...args:Array<any>):Credent
     return new NFTCredential(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectCredentialClass: unknown credid ${credid}`);
+  throw new Error(`Error - SelectCredentialClass: unknown credid`);
 };
 
 export class SECPCredential extends Credential {
@@ -33,7 +33,7 @@ export class SECPCredential extends Credential {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPCredential.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - SECPCredential.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPCREDENTIAL : AVMConstants.SECPCREDENTIAL_CODECONE;
@@ -70,7 +70,7 @@ export class NFTCredential extends Credential {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTCredential.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - NFTCredential.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTCREDENTIAL : AVMConstants.NFTCREDENTIAL_CODECONE;

--- a/src/apis/avm/credentials.ts
+++ b/src/apis/avm/credentials.ts
@@ -20,7 +20,7 @@ export const SelectCredentialClass = (credid:number, ...args:Array<any>):Credent
     return new NFTCredential(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectCredentialClass: unknown credid`);
+  throw new Error("Error - SelectCredentialClass: unknown credid");
 };
 
 export class SECPCredential extends Credential {
@@ -33,7 +33,7 @@ export class SECPCredential extends Credential {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPCredential.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - SECPCredential.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPCREDENTIAL : AVMConstants.SECPCREDENTIAL_CODECONE;
@@ -70,7 +70,7 @@ export class NFTCredential extends Credential {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTCredential.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - NFTCredential.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTCREDENTIAL : AVMConstants.NFTCREDENTIAL_CODECONE;

--- a/src/apis/avm/exporttx.ts
+++ b/src/apis/avm/exporttx.ts
@@ -54,7 +54,7 @@ export class ExportTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - ExportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - ExportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.EXPORTTX : AVMConstants.EXPORTTX_CODECONE;

--- a/src/apis/avm/exporttx.ts
+++ b/src/apis/avm/exporttx.ts
@@ -54,7 +54,7 @@ export class ExportTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - ExportTx.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - ExportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.EXPORTTX : AVMConstants.EXPORTTX_CODECONE;

--- a/src/apis/avm/importtx.ts
+++ b/src/apis/avm/importtx.ts
@@ -55,7 +55,7 @@ export class ImportTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - ImportTx.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - ImportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.IMPORTTX : AVMConstants.IMPORTTX_CODECONE;

--- a/src/apis/avm/importtx.ts
+++ b/src/apis/avm/importtx.ts
@@ -55,7 +55,7 @@ export class ImportTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - ImportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - ImportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.IMPORTTX : AVMConstants.IMPORTTX_CODECONE;

--- a/src/apis/avm/inputs.ts
+++ b/src/apis/avm/inputs.ts
@@ -26,7 +26,7 @@ export const SelectInputClass = (inputid:number, ...args:Array<any>):Input => {
     return new SECPTransferInput(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectInputClass: unknown inputid ${inputid}`);
+  throw new Error(`Error - SelectInputClass: unknown inputid`);
 };
 
 export class TransferableInput extends StandardTransferableInput {
@@ -84,7 +84,7 @@ export class SECPTransferInput extends AmountInput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPTransferInput.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - SECPTransferInput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPINPUTID : AVMConstants.SECPINPUTID_CODECONE;

--- a/src/apis/avm/inputs.ts
+++ b/src/apis/avm/inputs.ts
@@ -26,7 +26,7 @@ export const SelectInputClass = (inputid:number, ...args:Array<any>):Input => {
     return new SECPTransferInput(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectInputClass: unknown inputid`);
+  throw new Error("Error - SelectInputClass: unknown inputid");
 };
 
 export class TransferableInput extends StandardTransferableInput {
@@ -84,7 +84,7 @@ export class SECPTransferInput extends AmountInput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPTransferInput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - SECPTransferInput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPINPUTID : AVMConstants.SECPINPUTID_CODECONE;

--- a/src/apis/avm/operationtx.ts
+++ b/src/apis/avm/operationtx.ts
@@ -53,7 +53,7 @@ export class OperationTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - OperationTx.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - OperationTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.OPERATIONTX : AVMConstants.OPERATIONTX_CODECONE;

--- a/src/apis/avm/operationtx.ts
+++ b/src/apis/avm/operationtx.ts
@@ -53,7 +53,7 @@ export class OperationTx extends BaseTx {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - OperationTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - OperationTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.OPERATIONTX : AVMConstants.OPERATIONTX_CODECONE;

--- a/src/apis/avm/ops.ts
+++ b/src/apis/avm/ops.ts
@@ -287,7 +287,7 @@ export class SECPMintOperation extends Operation {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPMintOperation.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - SECPMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPMINTOPID : AVMConstants.SECPMINTOPID_CODECONE;
@@ -411,7 +411,7 @@ export class NFTMintOperation extends Operation {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTMintOperation.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - NFTMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTMINTOPID : AVMConstants.NFTMINTOPID_CODECONE;
@@ -565,7 +565,7 @@ export class NFTTransferOperation extends Operation {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTTransferOperation.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - NFTTransferOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTXFEROPID : AVMConstants.NFTXFEROPID_CODECONE;

--- a/src/apis/avm/ops.ts
+++ b/src/apis/avm/ops.ts
@@ -287,7 +287,7 @@ export class SECPMintOperation extends Operation {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - SECPMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPMINTOPID : AVMConstants.SECPMINTOPID_CODECONE;
@@ -411,7 +411,7 @@ export class NFTMintOperation extends Operation {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - NFTMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTMINTOPID : AVMConstants.NFTMINTOPID_CODECONE;
@@ -565,7 +565,7 @@ export class NFTTransferOperation extends Operation {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTTransferOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - NFTTransferOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTXFEROPID : AVMConstants.NFTXFEROPID_CODECONE;

--- a/src/apis/avm/outputs.ts
+++ b/src/apis/avm/outputs.ts
@@ -107,7 +107,7 @@ export class SECPTransferOutput extends AmountOutput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - SECPTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPXFEROUTPUTID : AVMConstants.SECPXFEROUTPUTID_CODECONE;
@@ -145,7 +145,7 @@ export class SECPMintOutput extends Output {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - SECPMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPMINTOUTPUTID : AVMConstants.SECPMINTOUTPUTID_CODECONE;
@@ -195,7 +195,7 @@ export class NFTMintOutput extends NFTOutput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - NFTMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTMINTOUTPUTID : AVMConstants.NFTMINTOUTPUTID_CODECONE;
@@ -281,7 +281,7 @@ export class NFTTransferOutput extends NFTOutput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
+        throw new Error("Error - NFTTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTXFEROUTPUTID : AVMConstants.NFTXFEROUTPUTID_CODECONE;

--- a/src/apis/avm/outputs.ts
+++ b/src/apis/avm/outputs.ts
@@ -107,7 +107,7 @@ export class SECPTransferOutput extends AmountOutput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPTransferOutput.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - SECPTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPXFEROUTPUTID : AVMConstants.SECPXFEROUTPUTID_CODECONE;
@@ -145,7 +145,7 @@ export class SECPMintOutput extends Output {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - SECPMintOutput.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - SECPMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.SECPMINTOUTPUTID : AVMConstants.SECPMINTOUTPUTID_CODECONE;
@@ -195,7 +195,7 @@ export class NFTMintOutput extends NFTOutput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTMintOutput.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - NFTMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTMINTOUTPUTID : AVMConstants.NFTMINTOUTPUTID_CODECONE;
@@ -281,7 +281,7 @@ export class NFTTransferOutput extends NFTOutput {
   setCodecID(codecID: number): void {
     if(codecID !== 0 && codecID !== 1) {
       /* istanbul ignore next */
-        throw new Error(`Error - NFTTransferOutput.setCodecID: codecID ${codecID}, is not valid. Valid codecIDs are 0 and 1.`);
+        throw new Error(`Error - NFTTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.`);
     }
     this._codecID = codecID;
     this._typeID = this._codecID === 0 ? AVMConstants.NFTXFEROUTPUTID : AVMConstants.NFTXFEROUTPUTID_CODECONE;

--- a/src/apis/avm/tx.ts
+++ b/src/apis/avm/tx.ts
@@ -43,7 +43,7 @@ export const SelectTxClass = (txtype:number, ...args:Array<any>):BaseTx => {
     return new ExportTx(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectTxClass: unknown txtype ${txtype}`);
+  throw new Error(`Error - SelectTxClass: unknown txtype`);
 };
 
 

--- a/src/apis/avm/tx.ts
+++ b/src/apis/avm/tx.ts
@@ -43,7 +43,7 @@ export const SelectTxClass = (txtype:number, ...args:Array<any>):BaseTx => {
     return new ExportTx(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectTxClass: unknown txtype`);
+  throw new Error("Error - SelectTxClass: unknown txtype");
 };
 
 

--- a/src/apis/avm/utxos.ts
+++ b/src/apis/avm/utxos.ts
@@ -146,7 +146,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
       utxovar.fromBuffer(utxo.toBuffer()); // forces a copy
     } else {
       /* istanbul ignore next */
-      throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string: ${utxo}`);
+      throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string`);
     }
     return utxovar
   }
@@ -446,7 +446,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
       let idx:number = out.getAddressIdx(spenders[j]);
       if(idx == -1) {
           /* istanbul ignore next */
-          throw new Error(`Error - UTXOSet.buildSECPMintTx: no such address in output: ${spenders[j]}`);
+          throw new Error(`Error - UTXOSet.buildSECPMintTx: no such address in output`);
       }
       mintOp.addSignatureIdx(idx, spenders[j]);
     }
@@ -586,7 +586,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
             idx = out.getAddressIdx(spenders[j]);
             if(idx == -1){
                 /* istanbul ignore next */
-                throw new Error(`Error - UTXOSet.buildCreateNFTMintTx: no such address in output: ${spenders[j]}`);
+                throw new Error(`Error - UTXOSet.buildCreateNFTMintTx: no such address in output`);
             }
             nftMintOperation.addSignatureIdx(idx, spenders[j]);
         }

--- a/src/apis/avm/utxos.ts
+++ b/src/apis/avm/utxos.ts
@@ -146,7 +146,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
       utxovar.fromBuffer(utxo.toBuffer()); // forces a copy
     } else {
       /* istanbul ignore next */
-      throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string`);
+      throw new Error("Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string");
     }
     return utxovar
   }
@@ -276,7 +276,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
 
     if(threshold > toAddresses.length) {
       /* istanbul ignore next */
-      throw new Error(`Error - UTXOSet.buildBaseTx: threshold is greater than number of addresses`);
+      throw new Error("Error - UTXOSet.buildBaseTx: threshold is greater than number of addresses");
     }
 
     if(typeof changeAddresses === "undefined") {
@@ -446,7 +446,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
       let idx:number = out.getAddressIdx(spenders[j]);
       if(idx == -1) {
           /* istanbul ignore next */
-          throw new Error(`Error - UTXOSet.buildSECPMintTx: no such address in output`);
+          throw new Error("Error - UTXOSet.buildSECPMintTx: no such address in output");
       }
       mintOp.addSignatureIdx(idx, spenders[j]);
     }
@@ -586,7 +586,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
             idx = out.getAddressIdx(spenders[j]);
             if(idx == -1){
                 /* istanbul ignore next */
-                throw new Error(`Error - UTXOSet.buildCreateNFTMintTx: no such address in output`);
+                throw new Error("Error - UTXOSet.buildCreateNFTMintTx: no such address in output");
             }
             nftMintOperation.addSignatureIdx(idx, spenders[j]);
         }

--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -527,7 +527,7 @@ export class EVMAPI extends JRPCAPI {
     const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();
 
     if(atomics.length === 0){
-      throw new Error(`Error - EVMAPI.buildImportTx: no atomic utxos to import`);
+      throw new Error("Error - EVMAPI.buildImportTx: no atomic utxos to import");
     }
 
     const builtUnsignedTx: UnsignedTx = utxoset.buildImportTx(
@@ -585,7 +585,7 @@ export class EVMAPI extends JRPCAPI {
     } else if (typeof destinationChain === "string") {
       destinationChain = bintools.cb58Decode(destinationChain); 
     } else if(!(destinationChain instanceof Buffer)) {
-      throw new Error(`Error - EVMAPI.buildExportTx: Invalid destinationChain type`);
+      throw new Error("Error - EVMAPI.buildExportTx: Invalid destinationChain type");
     }
     if(destinationChain.length !== 32) {
       throw new Error("Error - EVMAPI.buildExportTx: Destination ChainID must be 32 bytes in length.");
@@ -654,7 +654,7 @@ export class EVMAPI extends JRPCAPI {
         if (typeof address === 'string') {
           if (typeof this.parseAddress(address as string) === 'undefined') {
             /* istanbul ignore next */
-            throw new Error(`Error - Invalid address format`);
+            throw new Error("Error - Invalid address format");
           }
           addrs.push(address as string);
         } else {

--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -527,7 +527,7 @@ export class EVMAPI extends JRPCAPI {
     const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();
 
     if(atomics.length === 0){
-      throw new Error(`Error - EVMAPI.buildImportTx: no atomic utxos to import from ${srcChain} using addresses: ${ownerAddresses.join(', ')}`);
+      throw new Error(`Error - EVMAPI.buildImportTx: no atomic utxos to import`);
     }
 
     const builtUnsignedTx: UnsignedTx = utxoset.buildImportTx(
@@ -585,7 +585,7 @@ export class EVMAPI extends JRPCAPI {
     } else if (typeof destinationChain === "string") {
       destinationChain = bintools.cb58Decode(destinationChain); 
     } else if(!(destinationChain instanceof Buffer)) {
-      throw new Error(`Error - EVMAPI.buildExportTx: Invalid destinationChain type: ${typeof destinationChain}`);
+      throw new Error(`Error - EVMAPI.buildExportTx: Invalid destinationChain type`);
     }
     if(destinationChain.length !== 32) {
       throw new Error("Error - EVMAPI.buildExportTx: Destination ChainID must be 32 bytes in length.");
@@ -654,7 +654,7 @@ export class EVMAPI extends JRPCAPI {
         if (typeof address === 'string') {
           if (typeof this.parseAddress(address as string) === 'undefined') {
             /* istanbul ignore next */
-            throw new Error(`Error - EVMAPI.${caller}: Invalid address format ${address}`);
+            throw new Error(`Error - Invalid address format`);
           }
           addrs.push(address as string);
         } else {

--- a/src/apis/evm/credentials.ts
+++ b/src/apis/evm/credentials.ts
@@ -18,7 +18,7 @@ export const SelectCredentialClass = (credid: number, ...args: any[]): Credentia
     return new SECPCredential(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectCredentialClass: unknown credid ${credid}`);
+  throw new Error(`Error - SelectCredentialClass: unknown credid`);
 };
 
 export class SECPCredential extends Credential {

--- a/src/apis/evm/credentials.ts
+++ b/src/apis/evm/credentials.ts
@@ -18,7 +18,7 @@ export const SelectCredentialClass = (credid: number, ...args: any[]): Credentia
     return new SECPCredential(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectCredentialClass: unknown credid`);
+  throw new Error("Error - SelectCredentialClass: unknown credid");
 };
 
 export class SECPCredential extends Credential {

--- a/src/apis/evm/inputs.ts
+++ b/src/apis/evm/inputs.ts
@@ -32,7 +32,7 @@ export const SelectInputClass = (inputID: number, ...args: any[]): Input => {
     return new SECPTransferInput(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectInputClass: unknown inputID ${inputID}`);
+  throw new Error(`Error - SelectInputClass: unknown inputID`);
 };
 
 export class TransferableInput extends StandardTransferableInput {

--- a/src/apis/evm/inputs.ts
+++ b/src/apis/evm/inputs.ts
@@ -32,7 +32,7 @@ export const SelectInputClass = (inputID: number, ...args: any[]): Input => {
     return new SECPTransferInput(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectInputClass: unknown inputID`);
+  throw new Error("Error - SelectInputClass: unknown inputID");
 };
 
 export class TransferableInput extends StandardTransferableInput {

--- a/src/apis/evm/outputs.ts
+++ b/src/apis/evm/outputs.ts
@@ -22,7 +22,7 @@ export const SelectOutputClass = (outputID: number, ...args: any[]): Output => {
   if(outputID == EVMConstants.SECPXFEROUTPUTID){
     return new SECPTransferOutput( ...args);
   }
-  throw new Error(`Error - SelectOutputClass: unknown outputID ${outputID}`);
+  throw new Error(`Error - SelectOutputClass: unknown outputID`);
 }
 
 export class TransferableOutput extends StandardTransferableOutput{

--- a/src/apis/evm/outputs.ts
+++ b/src/apis/evm/outputs.ts
@@ -22,7 +22,7 @@ export const SelectOutputClass = (outputID: number, ...args: any[]): Output => {
   if(outputID == EVMConstants.SECPXFEROUTPUTID){
     return new SECPTransferOutput( ...args);
   }
-  throw new Error(`Error - SelectOutputClass: unknown outputID`);
+  throw new Error("Error - SelectOutputClass: unknown outputID");
 }
 
 export class TransferableOutput extends StandardTransferableOutput{

--- a/src/apis/evm/tx.ts
+++ b/src/apis/evm/tx.ts
@@ -38,7 +38,7 @@ export const SelectTxClass = (txTypeID: number, ...args: any[]): EVMBaseTx => {
     return new ExportTx(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectTxClass: unknown txType`);
+  throw new Error("Error - SelectTxClass: unknown txType");
 };
 
 export class UnsignedTx extends EVMStandardUnsignedTx<KeyPair, KeyChain, EVMBaseTx> {

--- a/src/apis/evm/tx.ts
+++ b/src/apis/evm/tx.ts
@@ -38,7 +38,7 @@ export const SelectTxClass = (txTypeID: number, ...args: any[]): EVMBaseTx => {
     return new ExportTx(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectTxClass: unknown txType ${txTypeID}`);
+  throw new Error(`Error - SelectTxClass: unknown txType`);
 };
 
 export class UnsignedTx extends EVMStandardUnsignedTx<KeyPair, KeyChain, EVMBaseTx> {

--- a/src/apis/evm/utxos.ts
+++ b/src/apis/evm/utxos.ts
@@ -159,7 +159,7 @@ import { ExportTx } from './exporttx';
        utxovar.fromBuffer(utxo.toBuffer()); // forces a copy
      } else {
        /* istanbul ignore next */
-       throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string`);
+       throw new Error("Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string");
      }
      return utxovar
    }
@@ -209,7 +209,7 @@ import { ExportTx } from './exporttx';
              const idx: number = uout.getAddressIdx(spender);
              if (idx === -1) {
                /* istanbul ignore next */
-               throw new Error(`Error - UTXOSet.getMinimumSpendable: no such address in output`);
+               throw new Error("Error - UTXOSet.getMinimumSpendable: no such address in output");
              }
              xferin.getInput().addSignatureIdx(idx, spender);
            });
@@ -325,7 +325,7 @@ import { ExportTx } from './exporttx';
          const idx: number = output.getAddressIdx(spender);
          if (idx === -1) {
            /* istanbul ignore next */
-           throw new Error(`Error - UTXOSet.buildImportTx: no such address in output`);
+           throw new Error("Error - UTXOSet.buildImportTx: no such address in output");
          }
          xferin.getInput().addSignatureIdx(idx, spender);
        });

--- a/src/apis/evm/utxos.ts
+++ b/src/apis/evm/utxos.ts
@@ -159,7 +159,7 @@ import { ExportTx } from './exporttx';
        utxovar.fromBuffer(utxo.toBuffer()); // forces a copy
      } else {
        /* istanbul ignore next */
-       throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string: ${utxo}`);
+       throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string`);
      }
      return utxovar
    }
@@ -209,7 +209,7 @@ import { ExportTx } from './exporttx';
              const idx: number = uout.getAddressIdx(spender);
              if (idx === -1) {
                /* istanbul ignore next */
-               throw new Error(`Error - UTXOSet.getMinimumSpendable: no such address in output: ${spender}`);
+               throw new Error(`Error - UTXOSet.getMinimumSpendable: no such address in output`);
              }
              xferin.getInput().addSignatureIdx(idx, spender);
            });
@@ -325,7 +325,7 @@ import { ExportTx } from './exporttx';
          const idx: number = output.getAddressIdx(spender);
          if (idx === -1) {
            /* istanbul ignore next */
-           throw new Error(`Error - UTXOSet.buildImportTx: no such address in output: ${spender}`);
+           throw new Error(`Error - UTXOSet.buildImportTx: no such address in output`);
          }
          xferin.getInput().addSignatureIdx(idx, spender);
        });

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -351,7 +351,7 @@ export class PlatformVMAPI extends JRPCAPI {
   getBalance = async (address:string):Promise<object> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - PlatformVMAPI.getBalance: Invalid address format`);
+      throw new Error("Error - PlatformVMAPI.getBalance: Invalid address format");
     }
     const params:any = {
       address
@@ -1405,7 +1405,7 @@ export class PlatformVMAPI extends JRPCAPI {
         if (typeof addresses[i] === 'string') {
           if (typeof this.parseAddress(addresses[i] as string) === 'undefined') {
             /* istanbul ignore next */
-            throw new Error(`Error - Invalid address format`);
+            throw new Error("Error - Invalid address format");
           }
           addrs.push(addresses[i] as string);
         } else {

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -351,7 +351,7 @@ export class PlatformVMAPI extends JRPCAPI {
   getBalance = async (address:string):Promise<object> => {
     if (typeof this.parseAddress(address) === 'undefined') {
       /* istanbul ignore next */
-      throw new Error(`Error - PlatformVMAPI.getBalance: Invalid address format ${address}`);
+      throw new Error(`Error - PlatformVMAPI.getBalance: Invalid address format`);
     }
     const params:any = {
       address
@@ -1405,7 +1405,7 @@ export class PlatformVMAPI extends JRPCAPI {
         if (typeof addresses[i] === 'string') {
           if (typeof this.parseAddress(addresses[i] as string) === 'undefined') {
             /* istanbul ignore next */
-            throw new Error(`Error - PlatformVMAPI.${caller}: Invalid address format ${addresses[i]}`);
+            throw new Error(`Error - Invalid address format`);
           }
           addrs.push(addresses[i] as string);
         } else {

--- a/src/apis/platformvm/credentials.ts
+++ b/src/apis/platformvm/credentials.ts
@@ -18,7 +18,7 @@ export const SelectCredentialClass = (credid:number, ...args:Array<any>):Credent
     return new SECPCredential(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectCredentialClass: unknown credid`);
+  throw new Error("Error - SelectCredentialClass: unknown credid");
 };
 
 export class SECPCredential extends Credential {

--- a/src/apis/platformvm/credentials.ts
+++ b/src/apis/platformvm/credentials.ts
@@ -18,7 +18,7 @@ export const SelectCredentialClass = (credid:number, ...args:Array<any>):Credent
     return new SECPCredential(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectCredentialClass: unknown credid ${credid}`);
+  throw new Error(`Error - SelectCredentialClass: unknown credid`);
 };
 
 export class SECPCredential extends Credential {

--- a/src/apis/platformvm/inputs.ts
+++ b/src/apis/platformvm/inputs.ts
@@ -29,7 +29,7 @@ export const SelectInputClass = (inputid:number, ...args:Array<any>):Input => {
     return new StakeableLockIn(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectInputClass: unknown inputid ${inputid}`);
+  throw new Error(`Error - SelectInputClass: unknown inputid`);
 };
 
 export class ParseableInput extends StandardParseableInput{

--- a/src/apis/platformvm/inputs.ts
+++ b/src/apis/platformvm/inputs.ts
@@ -29,7 +29,7 @@ export const SelectInputClass = (inputid:number, ...args:Array<any>):Input => {
     return new StakeableLockIn(...args);
   }
   /* istanbul ignore next */
-  throw new Error(`Error - SelectInputClass: unknown inputid`);
+  throw new Error("Error - SelectInputClass: unknown inputid");
 };
 
 export class ParseableInput extends StandardParseableInput{

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -45,7 +45,7 @@ export const SelectTxClass = (txtype:number, ...args:Array<any>):BaseTx => {
     return new CreateSubnetTx(...args);
   } 
   /* istanbul ignore next */
-  throw new Error(`Error - SelectTxClass: unknown txtype`);
+  throw new Error("Error - SelectTxClass: unknown txtype");
 };
 
 export class UnsignedTx extends StandardUnsignedTx<KeyPair, KeyChain, BaseTx> {

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -45,7 +45,7 @@ export const SelectTxClass = (txtype:number, ...args:Array<any>):BaseTx => {
     return new CreateSubnetTx(...args);
   } 
   /* istanbul ignore next */
-  throw new Error(`Error - SelectTxClass: unknown txtype ${txtype}`);
+  throw new Error(`Error - SelectTxClass: unknown txtype`);
 };
 
 export class UnsignedTx extends StandardUnsignedTx<KeyPair, KeyChain, BaseTx> {

--- a/src/apis/platformvm/utxos.ts
+++ b/src/apis/platformvm/utxos.ts
@@ -142,7 +142,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
       utxovar.fromBuffer(utxo.toBuffer()); // forces a copy
     } else {
       /* istanbul ignore next */
-      throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string: ${utxo}`);
+      throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string`);
     }
     return utxovar
   }

--- a/src/apis/platformvm/utxos.ts
+++ b/src/apis/platformvm/utxos.ts
@@ -142,7 +142,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
       utxovar.fromBuffer(utxo.toBuffer()); // forces a copy
     } else {
       /* istanbul ignore next */
-      throw new Error(`Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string`);
+      throw new Error("Error - UTXO.parseUTXO: utxo parameter is not a UTXO or string");
     }
     return utxovar
   }
@@ -492,7 +492,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO>{
 
     if (threshold > toAddresses.length) {
       /* istanbul ignore next */
-      throw new Error(`Error - UTXOSet.buildBaseTx: threshold is greater than number of addresses`);
+      throw new Error("Error - UTXOSet.buildBaseTx: threshold is greater than number of addresses");
     }
 
     if (typeof changeAddresses === "undefined") {

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -64,7 +64,7 @@ export class JRPCAPI extends APIBase {
             resp.data = JSON.parse(resp.data);
           }
           if (typeof resp.data === 'object' && (resp.data === null || 'error' in resp.data)) {
-            throw new Error(`Error`);
+            throw new Error("Error");
           }
         }
         return resp;

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -64,7 +64,7 @@ export class JRPCAPI extends APIBase {
             resp.data = JSON.parse(resp.data);
           }
           if (typeof resp.data === 'object' && (resp.data === null || 'error' in resp.data)) {
-            throw new Error(`Error returned: ${JSON.stringify(resp.data)}`);
+            throw new Error(`Error`);
           }
         }
         return resp;

--- a/src/common/nbytes.ts
+++ b/src/common/nbytes.ts
@@ -75,7 +75,7 @@ export abstract class NBytes extends Serializable {
     try {
       if (buff.length - offset < this.bsize) {
         /* istanbul ignore next */
-        throw new Error(`Error`);
+        throw new Error("Error - NBytes.fromBuffer: not enough space available in buffer.");
       }
 
       this.bytes = bintools.copyFrom(buff, offset, offset + this.bsize);

--- a/src/common/nbytes.ts
+++ b/src/common/nbytes.ts
@@ -75,7 +75,7 @@ export abstract class NBytes extends Serializable {
     try {
       if (buff.length - offset < this.bsize) {
         /* istanbul ignore next */
-        throw new Error(`Buffer length must be ${this.bsize} bytes. Only have ${buff.length - offset} remaining in buffer.`);
+        throw new Error(`Error`);
       }
 
       this.bytes = bintools.copyFrom(buff, offset, offset + this.bsize);

--- a/src/common/utxos.ts
+++ b/src/common/utxos.ts
@@ -594,7 +594,7 @@ export abstract class StandardUTXOSet<UTXOClass extends StandardUTXO> extends Se
         uSet = this.union(utxoset);
         return uSet.difference(this) as this;
       default:
-        throw new Error(`Error - StandardUTXOSet.mergeByRule: bad MergeRule`);
+        throw new Error("Error - StandardUTXOSet.mergeByRule: bad MergeRule");
     }
   };
 }

--- a/src/common/utxos.ts
+++ b/src/common/utxos.ts
@@ -594,7 +594,7 @@ export abstract class StandardUTXOSet<UTXOClass extends StandardUTXO> extends Se
         uSet = this.union(utxoset);
         return uSet.difference(this) as this;
       default:
-        throw new Error(`Error - StandardUTXOSet.mergeByRule: bad MergeRule - ${mergeRule}`);
+        throw new Error(`Error - StandardUTXOSet.mergeByRule: bad MergeRule`);
     }
   };
 }

--- a/tests/apis/avm/inputs.test.ts
+++ b/tests/apis/avm/inputs.test.ts
@@ -131,6 +131,6 @@ describe('Inputs', () => {
     const secpTransferInput: SECPTransferInput = new SECPTransferInput((utxos[0].getOutput() as AmountOutput).getAmount());
     expect(() => {
       secpTransferInput.setCodecID(2)
-    }).toThrow("Error - SECPTransferInput.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+    }).toThrow("Error - SECPTransferInput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
   });
 });

--- a/tests/apis/avm/ops.test.ts
+++ b/tests/apis/avm/ops.test.ts
@@ -89,7 +89,7 @@ describe('Operations', () => {
           const nftMintOperation: NFTMintOperation = new NFTMintOperation(0, payload, outputOwners);
           expect(() => {
             nftMintOperation.setCodecID(2)
-          }).toThrow("Error - NFTMintOperation.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+          }).toThrow("Error - NFTMintOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
         });
     })
 
@@ -150,7 +150,7 @@ describe('Operations', () => {
           const nftTransferOperation: NFTTransferOperation = new NFTTransferOperation(new NFTTransferOutput(1000, payload, addrs, locktime, 1));
           expect(() => {
             nftTransferOperation.setCodecID(2)
-          }).toThrow("Error - NFTTransferOperation.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+          }).toThrow("Error - NFTTransferOperation.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
         });
     })
 

--- a/tests/apis/avm/outputs.test.ts
+++ b/tests/apis/avm/outputs.test.ts
@@ -59,7 +59,7 @@ describe('Outputs', () => {
           const nftMintOutput: NFTMintOutput = new NFTMintOutput(1, addrs, fallLocktime, 1);
           expect(() => {
             nftMintOutput.setCodecID(2)
-          }).toThrow("Error - NFTMintOutput.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+          }).toThrow("Error - NFTMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
       });
 
       test('Functionality', () => {
@@ -173,7 +173,7 @@ describe('Outputs', () => {
           const secPTransferOutput: SECPTransferOutput = new SECPTransferOutput(new BN(10000), addrs, locktime, 3);
           expect(() => {
             secPTransferOutput.setCodecID(2)
-          }).toThrow("Error - SECPTransferOutput.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+          }).toThrow("Error - SECPTransferOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
       });
 
       test('SECPMintOutput', () => {
@@ -222,7 +222,7 @@ describe('Outputs', () => {
           const secpMintOutput: SECPMintOutput = new SECPMintOutput(addrs, locktime, 3);
           expect(() => {
             secpMintOutput.setCodecID(2)
-          }).toThrow("Error - SECPMintOutput.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+          }).toThrow("Error - SECPMintOutput.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
       });
     });
 });

--- a/tests/apis/avm/tx.test.ts
+++ b/tests/apis/avm/tx.test.ts
@@ -180,7 +180,7 @@ describe('Transactions', () => {
     const baseTx: BaseTx = new BaseTx();
     expect(() => {
       baseTx.setCodecID(2)
-    }).toThrow("Error - BaseTx.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+    }).toThrow("Error - BaseTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
   });
 
   test("CreateAssetTx codecIDs", () => {
@@ -199,7 +199,7 @@ describe('Transactions', () => {
     const createAssetTx: CreateAssetTx = new CreateAssetTx();
     expect(() => {
       createAssetTx.setCodecID(2)
-    }).toThrow("Error - CreateAssetTx.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+    }).toThrow("Error - CreateAssetTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
   });
 
   test("OperationTx codecIDs", () => {
@@ -218,7 +218,7 @@ describe('Transactions', () => {
     const operationTx: OperationTx = new OperationTx();
     expect(() => {
       operationTx.setCodecID(2)
-    }).toThrow("Error - OperationTx.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+    }).toThrow("Error - OperationTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
   });
 
   test("ImportTx codecIDs", () => {
@@ -237,7 +237,7 @@ describe('Transactions', () => {
     const importTx: ImportTx = new ImportTx();
     expect(() => {
       importTx.setCodecID(2)
-    }).toThrow("Error - ImportTx.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+    }).toThrow("Error - ImportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
   });
 
   test("ExportTx codecIDs", () => {
@@ -256,7 +256,7 @@ describe('Transactions', () => {
     const exportTx: ExportTx = new ExportTx();
     expect(() => {
       exportTx.setCodecID(2)
-    }).toThrow("Error - ExportTx.setCodecID: codecID 2, is not valid. Valid codecIDs are 0 and 1.");
+    }).toThrow("Error - ExportTx.setCodecID: invalid codecID. Valid codecIDs are 0 and 1.");
   });
 
   test('Create small BaseTx that is Goose Egg Tx', async () => {


### PR DESCRIPTION
* Avoid directly quoting potentially untrusted inputs in an error message
* Add example scripts
  * `examples/avm/addressFromBuffer.ts`
  * `examples/avm/createAddress.ts`
  * `examples/avm/getAVAXAssetID.ts`
  * `examples/avm/getAllBalances.ts`
  * `examples/avm/getAssetDescription.ts`
  * `examples/avm/getBalance.ts`
  * `examples/avm/getBlockchainAlias.ts`
  * `examples/avm/getBlockchainID.ts`
  * `examples/avm/getCreationTxFee.ts`
  * `examples/avm/getDefaultCreationTxFee.ts`
  * `examples/avm/getDefaultTxFee.ts`
  * `examples/avm/getTx.ts`
  * `examples/avm/getTxFee.ts`
  * `examples/avm/getTxStatus.ts`
  * `examples/avm/keyChain.ts`
  * `examples/avm/listAddresses.ts`
  * `examples/avm/newKeyChain.ts`
  * `examples/avm/parseAddress.ts`
  * `examples/avm/refreshBlockchainID.ts`
  * `examples/avm/setAVAXAssetID.ts`
  * `examples/avm/setBlockchainAlias.ts`
  * `examples/avm/setCreationTxFee.ts`
  * `examples/avm/setTxFee.ts`