### PR TITLE
* Add `requestConfig` of type `AxiosRequestConfig`

### DIFF
--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -121,7 +121,27 @@ export default class AvalancheCore {
    * @param value Header value
    */
   setHeader = (key:string,value:string):void => {
-    this.headers[key] = value
+    this.headers[key] = value;
+  }
+
+  /**
+   * Removes a previously added custom header.
+   * 
+   * @param key Header name
+   */
+  removeHeader = (key: string):void => {
+    delete this.headers[key];
+  }
+
+  /**
+   * Removes all headers.
+   */
+  removeAllHeaders = ():void => {
+    for (let prop in this.headers) {
+      if (Object.prototype.hasOwnProperty.call(this.headers, prop)) {
+        delete this.headers[prop];
+      }
+    }
   }
 
   /**
@@ -132,6 +152,26 @@ export default class AvalancheCore {
    */
   setRequestConfig = (key: string, value: string|boolean): void => {
     this.requestConfig[key] = value;
+  }
+
+  /**
+   * Removes a previously added request config.
+   * 
+   * @param key Header name
+   */
+  removeRequestConfig = (key: string):void => {
+    delete this.requestConfig[key];
+  }
+
+  /**
+   * Removes all request configs.
+   */
+  removeAllRequestConfigs = ():void => {
+    for (let prop in this.requestConfig) {
+      if (Object.prototype.hasOwnProperty.call(this.requestConfig, prop)) {
+        delete this.requestConfig[prop];
+      }
+    }
   }
 
   /**

--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -32,6 +32,8 @@ export default class AvalancheCore {
 
   protected headers:{ [k: string]: string } = {};
 
+  protected requestConfig: AxiosRequestConfig = {};
+
   protected apis:{ [k: string]: APIBase } = {};
 
   /**
@@ -79,6 +81,11 @@ export default class AvalancheCore {
   getHeaders = ():object => this.headers;
 
   /**
+   * Returns the custom request config
+   */
+  getRequestConfig = (): AxiosRequestConfig => this.requestConfig;
+
+  /**
      * Returns the networkID;
      */
   getNetworkID = ():number => this.networkID;
@@ -109,12 +116,22 @@ export default class AvalancheCore {
 
   /**
    * Adds a new custom header to be included with all requests.
-   *
+   * 
    * @param key Header name
    * @param value Header value
    */
   setHeader = (key:string,value:string):void => {
     this.headers[key] = value
+  }
+
+  /**
+   * Adds a new custom config value to be included with all requests.
+   *
+   * @param key Config name
+   * @param value Config value
+   */
+  setRequestConfig = (key: string, value: string|boolean): void => {
+    this.requestConfig[key] = value;
   }
 
   /**
@@ -187,11 +204,15 @@ export default class AvalancheCore {
     axiosConfig:AxiosRequestConfig = undefined): Promise<RequestResponseData> => {
     let config:AxiosRequestConfig;
     if (axiosConfig) {
-      config = axiosConfig;
+      config = {
+        ...axiosConfig,
+        ...this.requestConfig
+      }
     } else {
       config = {
         baseURL: `${this.protocol}://${this.ip}:${this.port}`,
         responseType: 'text',
+        ...this.requestConfig
       };
     }
     config.url = baseurl;

--- a/tests/avalanche.test.ts
+++ b/tests/avalanche.test.ts
@@ -42,6 +42,11 @@ describe('Avalanche', () => {
         expect(avalanche.getNetworkID()).toBe(50);
         avalanche.setNetworkID(12345);
         expect(avalanche.getNetworkID()).toBe(12345);
+        expect(avalanche.getRequestConfig()).toStrictEqual({});
+        avalanche.setRequestConfig("withCredentials", true)
+        expect(avalanche.getRequestConfig()).toStrictEqual({
+          withCredentials: true
+        });
     });
 
     test('Endpoints correct', () => {

--- a/tests/avalanche.test.ts
+++ b/tests/avalanche.test.ts
@@ -42,11 +42,6 @@ describe('Avalanche', () => {
         expect(avalanche.getNetworkID()).toBe(50);
         avalanche.setNetworkID(12345);
         expect(avalanche.getNetworkID()).toBe(12345);
-        expect(avalanche.getRequestConfig()).toStrictEqual({});
-        avalanche.setRequestConfig("withCredentials", true)
-        expect(avalanche.getRequestConfig()).toStrictEqual({
-          withCredentials: true
-        });
     });
 
     test('Endpoints correct', () => {
@@ -92,9 +87,39 @@ describe('Avalanche', () => {
 
     test("Customize headers", () => {
       avalanche.setHeader("X-Custom-Header", "example");
+      avalanche.setHeader("X-Foo", "Foo");
+      avalanche.setHeader("X-Bar", "Bar");
       expect(avalanche.getHeaders()).toStrictEqual({
-        "X-Custom-Header": "example"
+        "X-Custom-Header": "example",
+        "X-Foo": "Foo",
+        "X-Bar": "Bar",
       });
+      avalanche.removeHeader("X-Foo");
+      expect(avalanche.getHeaders()).toStrictEqual({
+        "X-Custom-Header": "example",
+        "X-Bar": "Bar",
+      });
+      avalanche.removeAllHeaders();
+      expect(avalanche.getHeaders()).toStrictEqual({});
+    });
+
+    test("Customize request config", () => {
+      expect(avalanche.getRequestConfig()).toStrictEqual({});
+      avalanche.setRequestConfig("withCredentials", true)
+      avalanche.setRequestConfig("withFoo", "Foo")
+      avalanche.setRequestConfig("withBar", "Bar")
+      expect(avalanche.getRequestConfig()).toStrictEqual({
+        withCredentials: true,
+        withFoo: "Foo",
+        withBar: "Bar"
+      });
+      avalanche.removeRequestConfig("withFoo");
+      expect(avalanche.getRequestConfig()).toStrictEqual({
+        withCredentials: true,
+        withBar: "Bar"
+      });
+      avalanche.removeAllRequestConfigs();
+      expect(avalanche.getRequestConfig()).toStrictEqual({});
     });
 });
 


### PR DESCRIPTION
## Additions

* Add `requestConfig` of type `AxiosRequestConfig`
* Add getter `getRequestConfig`
* Add setter `setRequestConfig`
* Use spread operator to add `requestConfig` to `axiosConfig` which is passed in to `_request`
* Add `removeHeader`
* Add `removeAllHeaders`
* Add `removeRequestConfig`
* Add `removeAllRequestConfigs`

```ts
avalanche.setRequestConfig("withCredentials", true)
avalanche.getRequestConfig()
// {
//    withCredentials: true
// };
```

## Example Tests

* [removeHeader](https://github.com/ava-labs/avalanchejs/blob/896f32573d8f258da9406d4a4f672f2e985611af/tests/avalanche.test.ts#L97)
* [removeAllHeaders](https://github.com/ava-labs/avalanchejs/blob/896f32573d8f258da9406d4a4f672f2e985611af/tests/avalanche.test.ts#L102)
* [removeRequestConfig](https://github.com/ava-labs/avalanchejs/blob/896f32573d8f258da9406d4a4f672f2e985611af/tests/avalanche.test.ts#L116)
* [removeAllRequestConfigs](https://github.com/ava-labs/avalanchejs/blob/896f32573d8f258da9406d4a4f672f2e985611af/tests/avalanche.test.ts#L121)
