### PR TITLE
Integrate the new Index RPC

### DIFF
--- a/examples/index/README.md
+++ b/examples/index/README.md
@@ -2,7 +2,7 @@
 
 Example scripts for the Avalanche [Index RPC](https://docs.avax.network/build/avalanchego-apis/index-api)
 
-* [getContainerByID.ts.ts](./getContainerByID.ts.ts)
+* [getContainerByID.ts](./getContainerByID.ts)
 * [getContainerByIndex.ts](./getContainerByIndex.ts)
 * [getContainerRange.ts](./getContainerRange.ts)
 * [getIndex.ts](./getIndex.ts)

--- a/examples/index/README.md
+++ b/examples/index/README.md
@@ -1,0 +1,10 @@
+# Index RPC
+
+Example scripts for the Avalanche [Index RPC](https://docs.avax.network/build/avalanchego-apis/index-api)
+
+* [getContainerByID.ts.ts](./getContainerByID.ts.ts)
+* [getContainerByIndex.ts](./getContainerByIndex.ts)
+* [getContainerRange.ts](./getContainerRange.ts)
+* [getIndex.ts](./getIndex.ts)
+* [getLastAccepted.ts](./getLastAccepted.ts)
+* [isAccepted.ts](./isAccepted.ts)

--- a/examples/index/getContainerByID.ts
+++ b/examples/index/getContainerByID.ts
@@ -14,9 +14,10 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
 const index: IndexAPI = avalanche.Index();
   
 const main = async (): Promise<any> => {
-  const containerID: string = "2CiVMmk7Uk1SaKzYYkrbQjiBbd7rDBUocNjpzUJxhsJ27ezJcF";
+  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT";
   const encoding: string = 'cb58';
-  const containerByIndex: GetContainerByIDResponse = await index.getContainerByID(containerID, encoding);
+  const baseurl: string = "/ext/index/C/block"
+  const containerByIndex: GetContainerByIDResponse = await index.getContainerByID(containerID, encoding, baseurl);
   console.log(containerByIndex);
 }
     

--- a/examples/index/getContainerByID.ts
+++ b/examples/index/getContainerByID.ts
@@ -1,0 +1,24 @@
+import { 
+  Avalanche
+} from "../../src";
+import { IndexAPI } from "../../src/apis/index";
+import { 
+  GetContainerByIDResponse
+} from '../../src/common/interfaces';
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const index: IndexAPI = avalanche.Index();
+  
+const main = async (): Promise<any> => {
+  const containerID: string = "2CiVMmk7Uk1SaKzYYkrbQjiBbd7rDBUocNjpzUJxhsJ27ezJcF";
+  const encoding: string = 'cb58';
+  const containerByIndex: GetContainerByIDResponse = await index.getContainerByID(containerID, encoding);
+  console.log(containerByIndex);
+}
+    
+main()
+  

--- a/examples/index/getContainerByIndex.ts
+++ b/examples/index/getContainerByIndex.ts
@@ -16,7 +16,8 @@ const index: IndexAPI = avalanche.Index();
 const main = async (): Promise<any> => {
   const idx: string = "0";
   const encoding: string = 'cb58';
-  const containerByIndex: GetContainerByIndexResponse = await index.getContainerByIndex(idx, encoding);
+  const baseurl: string = "/ext/index/C/block"
+  const containerByIndex: GetContainerByIndexResponse = await index.getContainerByIndex(idx, encoding, baseurl);
   console.log(containerByIndex);
 }
     

--- a/examples/index/getContainerByIndex.ts
+++ b/examples/index/getContainerByIndex.ts
@@ -1,0 +1,24 @@
+import { 
+  Avalanche
+} from "../../src";
+import { IndexAPI } from "../../src/apis/index";
+import { 
+  GetContainerByIndexResponse
+} from '../../src/common/interfaces';
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const index: IndexAPI = avalanche.Index();
+  
+const main = async (): Promise<any> => {
+  const idx: string = "0";
+  const encoding: string = 'cb58';
+  const containerByIndex: GetContainerByIndexResponse = await index.getContainerByIndex(idx, encoding);
+  console.log(containerByIndex);
+}
+    
+main()
+  

--- a/examples/index/getContainerRange.ts
+++ b/examples/index/getContainerRange.ts
@@ -17,7 +17,8 @@ const main = async (): Promise<any> => {
   const startIndex: number = 0;
   const numToFetch: number = 100;
   const encoding: string = "hex";
-  const containerRange: GetContainerRangeResponse[] = await index.getContainerRange(startIndex, numToFetch, encoding);
+  const baseurl: string = "/ext/index/C/block"
+  const containerRange: GetContainerRangeResponse[] = await index.getContainerRange(startIndex, numToFetch, encoding, baseurl);
   console.log(containerRange);
 }
     

--- a/examples/index/getContainerRange.ts
+++ b/examples/index/getContainerRange.ts
@@ -1,0 +1,25 @@
+import { 
+  Avalanche
+} from "../../src";
+import { IndexAPI } from "../../src/apis/index";
+import { 
+  GetContainerRangeResponse
+} from '../../src/common/interfaces';
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const index: IndexAPI = avalanche.Index();
+  
+const main = async (): Promise<any> => {
+  const startIndex: number = 0;
+  const numToFetch: number = 100;
+  const encoding: string = "hex";
+  const containerRange: GetContainerRangeResponse[] = await index.getContainerRange(startIndex, numToFetch, encoding);
+  console.log(containerRange);
+}
+    
+main()
+  

--- a/examples/index/getIndex.ts
+++ b/examples/index/getIndex.ts
@@ -11,11 +11,11 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
 const index: IndexAPI = avalanche.Index();
   
 const main = async (): Promise<any> => {
-  const containerID: string = "2CiVMmk7Uk1SaKzYYkrbQjiBbd7rDBUocNjpzUJxhsJ27ezJcF";
+  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT";
   const encoding: string = "hex";
-  const containerRange: string = await index.getIndex(containerID, encoding);
+  const baseurl: string = "/ext/index/C/block"
+  const containerRange: string = await index.getIndex(containerID, encoding, baseurl);
   console.log(containerRange);
 }
     
 main()
-  

--- a/examples/index/getIndex.ts
+++ b/examples/index/getIndex.ts
@@ -1,0 +1,21 @@
+import { 
+  Avalanche
+} from "../../src";
+import { IndexAPI } from "../../src/apis/index";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const index: IndexAPI = avalanche.Index();
+  
+const main = async (): Promise<any> => {
+  const containerID: string = "2CiVMmk7Uk1SaKzYYkrbQjiBbd7rDBUocNjpzUJxhsJ27ezJcF";
+  const encoding: string = "hex";
+  const containerRange: string = await index.getIndex(containerID, encoding);
+  console.log(containerRange);
+}
+    
+main()
+  

--- a/examples/index/getLastAccepted.ts
+++ b/examples/index/getLastAccepted.ts
@@ -1,0 +1,23 @@
+import { 
+  Avalanche
+} from "../../src";
+import { IndexAPI } from "../../src/apis/index";
+import { 
+  GetLastAcceptedResponse,
+} from '../../src/common/interfaces';
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const index: IndexAPI = avalanche.Index();
+  
+const main = async (): Promise<any> => {
+  const encoding: string = 'cb58';
+  const lastAccepted: GetLastAcceptedResponse = await index.getLastAccepted(encoding);
+  console.log(lastAccepted);
+}
+    
+main()
+  

--- a/examples/index/getLastAccepted.ts
+++ b/examples/index/getLastAccepted.ts
@@ -15,7 +15,8 @@ const index: IndexAPI = avalanche.Index();
   
 const main = async (): Promise<any> => {
   const encoding: string = 'cb58';
-  const lastAccepted: GetLastAcceptedResponse = await index.getLastAccepted(encoding);
+  const baseurl: string = "/ext/index/C/block"  
+  const lastAccepted: GetLastAcceptedResponse = await index.getLastAccepted(encoding, baseurl);
   console.log(lastAccepted);
 }
     

--- a/examples/index/getLastAccepted.ts
+++ b/examples/index/getLastAccepted.ts
@@ -15,7 +15,7 @@ const index: IndexAPI = avalanche.Index();
   
 const main = async (): Promise<any> => {
   const encoding: string = 'cb58';
-  const baseurl: string = "/ext/index/C/block"  
+  const baseurl: string = "/ext/index/X/tx"  
   const lastAccepted: GetLastAcceptedResponse = await index.getLastAccepted(encoding, baseurl);
   console.log(lastAccepted);
 }

--- a/examples/index/isAccepted.ts
+++ b/examples/index/isAccepted.ts
@@ -11,9 +11,10 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
 const index: IndexAPI = avalanche.Index();
   
 const main = async (): Promise<any> => {
-  const containerID: string = "2CiVMmk7Uk1SaKzYYkrbQjiBbd7rDBUocNjpzUJxhsJ27ezJcF";
+  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT";
   const encoding: string = "hex";
-  const containerRange: boolean = await index.isAccepted(containerID, encoding);
+  const baseurl: string = "/ext/index/C/block"
+  const containerRange: boolean = await index.isAccepted(containerID, encoding, baseurl);
   console.log(containerRange);
 }
     

--- a/examples/index/isAccepted.ts
+++ b/examples/index/isAccepted.ts
@@ -1,0 +1,21 @@
+import { 
+  Avalanche
+} from "../../src";
+import { IndexAPI } from "../../src/apis/index";
+  
+const ip: string = 'localhost';
+const port: number = 9650;
+const protocol: string = 'http';
+const networkID: number = 12345;
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const index: IndexAPI = avalanche.Index();
+  
+const main = async (): Promise<any> => {
+  const containerID: string = "2CiVMmk7Uk1SaKzYYkrbQjiBbd7rDBUocNjpzUJxhsJ27ezJcF";
+  const encoding: string = "hex";
+  const containerRange: boolean = await index.isAccepted(containerID, encoding);
+  console.log(containerRange);
+}
+    
+main()
+  

--- a/src/apis/index/api.ts
+++ b/src/apis/index/api.ts
@@ -27,9 +27,10 @@ import {
  */
 export class IndexAPI extends JRPCAPI {
     /**
-     * TODO - add description
+     * Get last accepted tx, vtx or block
      *
      * @param encoding 
+     * @param baseurl
      *
      * @returns Returns a Promise<GetLastAcceptedResponse>.
      */
@@ -48,10 +49,11 @@ export class IndexAPI extends JRPCAPI {
     };
 
     /**
-     * TODO - add description
+     * Get container by index
      *
      * @param index
      * @param encoding 
+     * @param baseurl
      *
      * @returns Returns a Promise<GetContainerByIndexResponse>.
      */
@@ -71,10 +73,11 @@ export class IndexAPI extends JRPCAPI {
     };
 
     /**
-     * TODO - add description
+     * Get contrainer by ID
      *
      * @param containerID
      * @param encoding 
+     * @param baseurl
      *
      * @returns Returns a Promise<GetContainerByIDResponse>.
      */
@@ -94,11 +97,12 @@ export class IndexAPI extends JRPCAPI {
     };
 
     /**
-     * TODO - add description
+     * Get container range
      *
      * @param startIndex
      * @param numToFetch
      * @param encoding 
+     * @param baseurl
      *
      * @returns Returns a Promise<GetContainerRangeResponse>.
      */
@@ -119,10 +123,11 @@ export class IndexAPI extends JRPCAPI {
     };
 
     /**
-     * TODO - add description
+     * Get index by containerID
      *
      * @param containerID
      * @param encoding 
+     * @param baseurl
      *
      * @returns Returns a Promise<GetIndexResponse>.
      */
@@ -142,10 +147,11 @@ export class IndexAPI extends JRPCAPI {
     };
 
     /**
-     * TODO - add description
+     * Check if container is accepted
      *
      * @param containerID
      * @param encoding 
+     * @param baseurl
      *
      * @returns Returns a Promise<GetIsAcceptedResponse>.
      */

--- a/src/apis/index/api.ts
+++ b/src/apis/index/api.ts
@@ -1,0 +1,162 @@
+/**
+ * @packageDocumentation
+ * @module Index-Auth
+ */
+import AvalancheCore from '../../avalanche';
+import { JRPCAPI } from '../../common/jrpcapi';
+import { RequestResponseData } from '../../common/apibase';
+import { 
+    GetLastAcceptedParams, 
+    GetLastAcceptedResponse,
+    GetContainerByIndexParams,
+    GetContainerByIndexResponse,
+    GetContainerByIDParams,
+    GetContainerByIDResponse,
+    GetContainerRangeParams,
+    GetContainerRangeResponse,
+    GetIndexParams,
+    GetIsAcceptedParams,
+} from 'src/common/interfaces';
+
+/**
+ * Class for interacting with a node's IndexAPI.
+ *
+ * @category RPCAPIs
+ *
+ * @remarks This extends the [[JRPCAPI]] class. This class should not be directly called. Instead, use the [[Avalanche.addAPI]] function to register this interface with Avalanche.
+ */
+export class IndexAPI extends JRPCAPI {
+    /**
+     * TODO - add description
+     *
+     * @param encoding 
+     *
+     * @returns Returns a Promise<GetLastAcceptedResponse>.
+     */
+    getLastAccepted = async (encoding: string = "cb58"): Promise<GetLastAcceptedResponse> => {
+      const params: GetLastAcceptedParams = {
+        encoding
+      };
+
+      try {
+        const response: RequestResponseData = await this.callMethod("index.getLastAccepted", params);
+        return response['data']['result'];
+      } catch (error) {
+        console.log(error)
+      }
+    };
+
+    /**
+     * TODO - add description
+     *
+     * @param index
+     * @param encoding 
+     *
+     * @returns Returns a Promise<GetContainerByIndexResponse>.
+     */
+     getContainerByIndex = async (index: string = "0", encoding: string = "cb58"): Promise<GetContainerByIndexResponse> => {
+      const params: GetContainerByIndexParams = {
+        index,
+        encoding
+      };
+
+      try {
+        const response: RequestResponseData = await this.callMethod("index.getContainerByIndex", params);
+        return response['data']['result'];
+      } catch (error) {
+        console.log(error)
+      }
+    };
+
+    /**
+     * TODO - add description
+     *
+     * @param containerID
+     * @param encoding 
+     *
+     * @returns Returns a Promise<GetContainerByIDResponse>.
+     */
+     getContainerByID = async (containerID: string = "0", encoding: string = "cb58"): Promise<GetContainerByIDResponse> => {
+      const params: GetContainerByIDParams = {
+        containerID,
+        encoding
+      };
+
+      try {
+        const response: RequestResponseData = await this.callMethod("index.getContainerByID", params);
+        return response['data']['result'];
+      } catch (error) {
+        console.log(error)
+      }
+    };
+
+    /**
+     * TODO - add description
+     *
+     * @param startIndex
+     * @param numToFetch
+     * @param encoding 
+     *
+     * @returns Returns a Promise<GetContainerRangeResponse>.
+     */
+     getContainerRange = async (startIndex: number = 0, numToFetch: number = 100, encoding: string = "hex"): Promise<GetContainerRangeResponse[]> => {
+      const params: GetContainerRangeParams = {
+        startIndex,
+        numToFetch,
+        encoding
+      };
+
+      try {
+        const response: RequestResponseData = await this.callMethod("index.getContainerRange", params);
+        return response['data']['result'];
+      } catch (error) {
+        console.log(error)
+      }
+    };
+
+    /**
+     * TODO - add description
+     *
+     * @param containerID
+     * @param encoding 
+     *
+     * @returns Returns a Promise<GetIndexResponse>.
+     */
+     getIndex = async (containerID: string = "", encoding: string = "hex"): Promise<string> => {
+      const params: GetIndexParams = {
+        containerID,
+        encoding
+      };
+
+      try {
+        const response: RequestResponseData = await this.callMethod("index.getIndex", params);
+        return response['data']['result']['index'];
+      } catch (error) {
+        console.log(error)
+      }
+    };
+
+    /**
+     * TODO - add description
+     *
+     * @param containerID
+     * @param encoding 
+     *
+     * @returns Returns a Promise<GetIsAcceptedResponse>.
+     */
+     isAccepted = async (containerID: string = "", encoding: string = "hex"): Promise<boolean> => {
+      const params: GetIsAcceptedParams = {
+        containerID,
+        encoding
+      };
+
+      try {
+        const response: RequestResponseData = await this.callMethod("index.isAccepted", params);
+        return response['data']['result'];
+      } catch (error) {
+        console.log(error)
+      }
+    };
+
+    constructor(core: AvalancheCore, baseurl: string = "/ext/index/X/tx") { super(core, baseurl); }
+}

--- a/src/apis/index/api.ts
+++ b/src/apis/index/api.ts
@@ -106,7 +106,7 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetContainerRangeResponse>.
      */
-     getContainerRange = async (startIndex: number = 0, numToFetch: number = 100, encoding: string = "hex", baseurl: string = this.getBaseURL()): Promise<GetContainerRangeResponse[]> => {
+     getContainerRange = async (startIndex: number = 0, numToFetch: number = 100, encoding: string = "cb58", baseurl: string = this.getBaseURL()): Promise<GetContainerRangeResponse[]> => {
       this.setBaseURL(baseurl)
       const params: GetContainerRangeParams = {
         startIndex,
@@ -131,7 +131,7 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetIndexResponse>.
      */
-     getIndex = async (containerID: string = "", encoding: string = "hex", baseurl: string = this.getBaseURL()): Promise<string> => {
+     getIndex = async (containerID: string = "", encoding: string = "cb58", baseurl: string = this.getBaseURL()): Promise<string> => {
       this.setBaseURL(baseurl)
       const params: GetIndexParams = {
         containerID,
@@ -155,7 +155,7 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetIsAcceptedResponse>.
      */
-     isAccepted = async (containerID: string = "", encoding: string = "hex", baseurl: string = this.getBaseURL()): Promise<boolean> => {
+     isAccepted = async (containerID: string = "", encoding: string = "cb58", baseurl: string = this.getBaseURL()): Promise<boolean> => {
        this.setBaseURL(baseurl)
        const params: GetIsAcceptedParams = {
          containerID,

--- a/src/apis/index/api.ts
+++ b/src/apis/index/api.ts
@@ -33,7 +33,8 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetLastAcceptedResponse>.
      */
-    getLastAccepted = async (encoding: string = "cb58"): Promise<GetLastAcceptedResponse> => {
+     getLastAccepted = async (encoding: string = "cb58", baseurl: string = this.getBaseURL()): Promise<GetLastAcceptedResponse> => {
+      this.setBaseURL(baseurl)
       const params: GetLastAcceptedParams = {
         encoding
       };
@@ -54,7 +55,8 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetContainerByIndexResponse>.
      */
-     getContainerByIndex = async (index: string = "0", encoding: string = "cb58"): Promise<GetContainerByIndexResponse> => {
+     getContainerByIndex = async (index: string = "0", encoding: string = "cb58", baseurl: string = this.getBaseURL()): Promise<GetContainerByIndexResponse> => {
+      this.setBaseURL(baseurl)
       const params: GetContainerByIndexParams = {
         index,
         encoding
@@ -76,7 +78,8 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetContainerByIDResponse>.
      */
-     getContainerByID = async (containerID: string = "0", encoding: string = "cb58"): Promise<GetContainerByIDResponse> => {
+     getContainerByID = async (containerID: string = "0", encoding: string = "cb58", baseurl: string = this.getBaseURL()): Promise<GetContainerByIDResponse> => {
+      this.setBaseURL(baseurl)
       const params: GetContainerByIDParams = {
         containerID,
         encoding
@@ -99,7 +102,8 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetContainerRangeResponse>.
      */
-     getContainerRange = async (startIndex: number = 0, numToFetch: number = 100, encoding: string = "hex"): Promise<GetContainerRangeResponse[]> => {
+     getContainerRange = async (startIndex: number = 0, numToFetch: number = 100, encoding: string = "hex", baseurl: string = this.getBaseURL()): Promise<GetContainerRangeResponse[]> => {
+      this.setBaseURL(baseurl)
       const params: GetContainerRangeParams = {
         startIndex,
         numToFetch,
@@ -122,7 +126,8 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetIndexResponse>.
      */
-     getIndex = async (containerID: string = "", encoding: string = "hex"): Promise<string> => {
+     getIndex = async (containerID: string = "", encoding: string = "hex", baseurl: string = this.getBaseURL()): Promise<string> => {
+      this.setBaseURL(baseurl)
       const params: GetIndexParams = {
         containerID,
         encoding
@@ -144,18 +149,19 @@ export class IndexAPI extends JRPCAPI {
      *
      * @returns Returns a Promise<GetIsAcceptedResponse>.
      */
-     isAccepted = async (containerID: string = "", encoding: string = "hex"): Promise<boolean> => {
-      const params: GetIsAcceptedParams = {
-        containerID,
-        encoding
-      };
+     isAccepted = async (containerID: string = "", encoding: string = "hex", baseurl: string = this.getBaseURL()): Promise<boolean> => {
+       this.setBaseURL(baseurl)
+       const params: GetIsAcceptedParams = {
+         containerID,
+         encoding
+       };
 
-      try {
-        const response: RequestResponseData = await this.callMethod("index.isAccepted", params);
-        return response['data']['result'];
-      } catch (error) {
-        console.log(error)
-      }
+       try {
+         const response: RequestResponseData = await this.callMethod("index.isAccepted", params);
+         return response['data']['result'];
+       } catch (error) {
+         console.log(error)
+       }
     };
 
     constructor(core: AvalancheCore, baseurl: string = "/ext/index/X/tx") { super(core, baseurl); }

--- a/src/apis/index/index.ts
+++ b/src/apis/index/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -23,6 +23,10 @@ export interface Asset {
   denomination: number
 }
 
+export interface BaseIndexParams {
+  encoding: string
+}
+
 export interface BaseIndexResponse {
   id: string
   bytes: string
@@ -31,40 +35,33 @@ export interface BaseIndexResponse {
   index: string
 }
 
-export interface GetLastAcceptedParams {
-  encoding: string
-}
+export interface GetLastAcceptedParams extends BaseIndexParams {}
 
 export interface GetLastAcceptedResponse extends BaseIndexResponse {}
 
-export interface GetContainerByIndexParams {
-  index: string,
-  encoding: string
+export interface GetContainerByIndexParams extends BaseIndexParams {
+  index: string
 }
 
 export interface GetContainerByIndexResponse extends BaseIndexResponse {}
 
-export interface GetContainerByIDParams {
-  containerID: string,
-  encoding: string
+export interface GetContainerByIDParams extends BaseIndexParams {
+  containerID: string
 }
 
 export interface GetContainerByIDResponse extends BaseIndexResponse {}
 
-export interface GetContainerRangeParams {
+export interface GetContainerRangeParams extends BaseIndexParams {
   startIndex: number,
-  numToFetch: number,
-  encoding: string
+  numToFetch: number
 }
 
 export interface GetContainerRangeResponse extends BaseIndexResponse {}
 
-export interface GetIndexParams {
-  containerID: string,
-  encoding: string
+export interface GetIndexParams extends BaseIndexParams {
+  containerID: string
 }
 
-export interface GetIsAcceptedParams {
-  containerID: string,
-  encoding: string
+export interface GetIsAcceptedParams extends BaseIndexParams {
+  containerID: string
 }

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -22,3 +22,49 @@ export interface Asset {
   assetID: Buffer
   denomination: number
 }
+
+export interface BaseIndexResponse {
+  id: string
+  bytes: string
+  timestamp: string
+  encoding: string
+  index: string
+}
+
+export interface GetLastAcceptedParams {
+  encoding: string
+}
+
+export interface GetLastAcceptedResponse extends BaseIndexResponse {}
+
+export interface GetContainerByIndexParams {
+  index: string,
+  encoding: string
+}
+
+export interface GetContainerByIndexResponse extends BaseIndexResponse {}
+
+export interface GetContainerByIDParams {
+  containerID: string,
+  encoding: string
+}
+
+export interface GetContainerByIDResponse extends BaseIndexResponse {}
+
+export interface GetContainerRangeParams {
+  startIndex: number,
+  numToFetch: number,
+  encoding: string
+}
+
+export interface GetContainerRangeResponse extends BaseIndexResponse {}
+
+export interface GetIndexParams {
+  containerID: string,
+  encoding: string
+}
+
+export interface GetIsAcceptedParams {
+  containerID: string,
+  encoding: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { AVMAPI } from './apis/avm/api';
 import { EVMAPI } from './apis/evm/api';
 import { HealthAPI } from './apis/health/api';
 import { InfoAPI } from './apis/info/api';
+import { IndexAPI } from './apis/index/api';
 import { KeystoreAPI } from './apis/keystore/api';
 import { MetricsAPI } from './apis/metrics/api';
 import { PlatformVMAPI } from './apis/platformvm/api';
@@ -58,6 +59,11 @@ export default class Avalanche extends AvalancheCore {
      * Returns a reference to the Info RPC for a node.
      */
   Info = () => this.apis.info as InfoAPI;
+
+  /**
+     * Returns a reference to the Index RPC for a node.
+     */
+  Index = () => this.apis.index as IndexAPI;
 
   /**
      * Returns a reference to the Metrics RPC.
@@ -139,6 +145,7 @@ export default class Avalanche extends AvalancheCore {
       this.addAPI('cchain', EVMAPI, '/ext/bc/C/avax', cchainid);
       this.addAPI('health', HealthAPI);
       this.addAPI('info', InfoAPI);
+      this.addAPI('index', IndexAPI);
       this.addAPI('keystore', KeystoreAPI);
       this.addAPI('metrics', MetricsAPI);
       this.addAPI('pchain', PlatformVMAPI);
@@ -161,6 +168,7 @@ export * as avm from './apis/avm';
 export * as evm from './apis/evm';
 export * as health from './apis/health';
 export * as info from './apis/info';
+export * as index from './apis/index';
 export * as keystore from './apis/keystore';
 export * as metrics from './apis/metrics';
 export * as platformvm from './apis/platformvm';

--- a/tests/apis/index/api.test.ts
+++ b/tests/apis/index/api.test.ts
@@ -1,0 +1,43 @@
+import mockAxios from 'jest-mock-axios';
+import { Avalanche } from 'src';
+import { IndexAPI } from 'src/apis/index/api';
+
+describe('Index', () => {
+  const ip: string = '127.0.0.1';
+  const port: number = 9650;
+  const protocol: string = 'https';
+
+  const avalanche: Avalanche = new Avalanche(ip, port, protocol, 12345);
+  let index: IndexAPI;
+
+  let testEndpoints:Array<string> = ["/ext/opt/bin/bash/foo", "/dev/null", "/tmp"];
+  let encoding: string = 'cb58';
+
+  beforeAll(() => {
+    index = avalanche.Index();
+  });
+
+  afterEach(() => {
+    mockAxios.reset();
+  });
+
+  test('getLastAccepted', async () => {
+    const result = await index.getLastAccepted(encoding);
+    console.log(result)
+
+    // const payload:object = {
+    //   result: {
+    //     token: testToken,
+    //   },
+    // };
+    // const responseObj = {
+    //   data: payload,
+    // };
+
+    // mockAxios.mockResponse(responseObj);
+    // const response:string = await result;
+
+    // expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    // expect(response).toBe(testToken);
+  });
+});

--- a/tests/apis/index/api.test.ts
+++ b/tests/apis/index/api.test.ts
@@ -1,6 +1,7 @@
 import mockAxios from 'jest-mock-axios';
 import { Avalanche } from 'src';
 import { IndexAPI } from 'src/apis/index/api';
+import { GetLastAcceptedResponse } from 'src/common/interfaces';
 
 describe('Index', () => {
   const ip: string = '127.0.0.1';
@@ -10,8 +11,10 @@ describe('Index', () => {
   const avalanche: Avalanche = new Avalanche(ip, port, protocol, 12345);
   let index: IndexAPI;
 
-  let testEndpoints:Array<string> = ["/ext/opt/bin/bash/foo", "/dev/null", "/tmp"];
-  let encoding: string = 'cb58';
+  const id: string = '6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY';
+  const bytes: string =  '111115HRzXVDSeonLBcv6QdJkQFjPzPEobMWy7PyGuoheggsMCx73MVXZo2hJMEXXvR5gFFasTRJH36aVkLiWHtTTFcghyFTqjaHnBhdXTRiLaYcro3jpseqLAFVn3ngnAB47nebQiBBKmg3nFWKzQUDxMuE6uDGXgnGouDSaEKZxfKreoLHYNUxH56rgi5c8gKFYSDi8AWBgy26siwAWj6V8EgFnPVgm9pmKCfXio6BP7Bua4vrupoX8jRGqdrdkN12dqGAibJ78Rf44SSUXhEvJtPxAzjEGfiTyAm5BWFqPdheKN72HyrBBtwC6y7wG6suHngZ1PMBh93Ubkbt8jjjGoEgs5NjpasJpE8YA9ZMLTPeNZ6ELFxV99zA46wvkjAwYHGzegBXvzGU5pGPbg28iW3iKhLoYAnReysY4x3fBhjPBsags37Z9P3SqioVifVX4wwzxYqbV72u1AWZ4JNmsnhVDP196Gu99QTzmySGTVGP5ABNdZrngTRfmGTFCRbt9CHsgNbhgetkxbsEG7tySi3gFxMzGuJ2Npk2gnSr68LgtYdSHf48Ns';
+  const timestamp: string = '2021-04-02T15:34:00.262979-07:00';
+  const idx: string = '0';
 
   beforeAll(() => {
     index = avalanche.Index();
@@ -22,22 +25,146 @@ describe('Index', () => {
   });
 
   test('getLastAccepted', async () => {
-    const result = await index.getLastAccepted(encoding);
-    console.log(result)
+    const encoding: string = 'cb58';
+    const baseurl: string = "/ext/index/X/tx"  
+    const respobj = {
+      id,
+      bytes,
+      timestamp,
+      encoding,
+      idx
+    };
+    const result:Promise<object> = index.getLastAccepted(encoding, baseurl);
 
-    // const payload:object = {
-    //   result: {
-    //     token: testToken,
-    //   },
-    // };
-    // const responseObj = {
-    //   data: payload,
-    // };
+    const payload: object = {
+      result: respobj,
+    };
+    const responseObj = {
+      data: payload,
+    };
 
-    // mockAxios.mockResponse(responseObj);
-    // const response:string = await result;
+    mockAxios.mockResponse(responseObj);
+    const response: object = await result;
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(response)).toBe(JSON.stringify(respobj));
+  });
 
-    // expect(mockAxios.request).toHaveBeenCalledTimes(1);
-    // expect(response).toBe(testToken);
+  test('getContainerByIndex', async () => {
+    const encoding: string = 'cb58';
+    const baseurl: string = "/ext/index/X/tx"  
+    const respobj = {
+      id,
+      bytes,
+      timestamp,
+      encoding,
+      idx
+    };
+    const result:Promise<object> = index.getContainerByIndex(idx, encoding, baseurl);
+
+    const payload: object = {
+      result: respobj,
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response: object = await result;
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(response)).toBe(JSON.stringify(respobj));
+  });
+
+  test('getContainerByID', async () => {
+    const encoding: string = 'cb58';
+    const baseurl: string = "/ext/index/X/tx"  
+    const respobj = {
+      id,
+      bytes,
+      timestamp,
+      encoding,
+      idx
+    };
+    const result:Promise<object> = index.getContainerByIndex(id, encoding, baseurl);
+
+    const payload: object = {
+      result: respobj,
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response: object = await result;
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(response)).toBe(JSON.stringify(respobj));
+  });
+
+  test('getContainerRange', async () => {
+    const startIndex: number = 0;
+    const numToFetch: number = 100;
+    const encoding: string = "hex";
+    const baseurl: string = "/ext/index/X/tx"  
+    const respobj = {
+      id,
+      bytes,
+      timestamp,
+      encoding,
+      idx
+    };
+    const result:Promise<object[]> = index.getContainerRange(startIndex, numToFetch, encoding, baseurl);
+
+    const payload: object = {
+      result: respobj,
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response: object = await result;
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(response)).toBe(JSON.stringify(respobj));
+  });
+
+  test('getIndex', async () => {
+    const encoding: string = "hex";
+    const baseurl: string = "/ext/index/X/tx"  
+    const result:Promise<string> = index.getIndex(id, encoding, baseurl);
+
+    const payload:object = {
+      result: {
+        index: "0"
+      },
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response:string = await result;
+
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(response).toBe('0');
+
+  });
+
+  test('isAccepted', async () => {
+    const encoding: string = "hex";
+    const baseurl: string = "/ext/index/X/tx"  
+    const result:Promise<boolean> = index.isAccepted(id, encoding, baseurl);
+
+    const payload:object = {
+      result: true
+    };
+    const responseObj = {
+      data: payload,
+    };
+
+    mockAxios.mockResponse(responseObj);
+    const response:boolean = await result;
+
+    expect(mockAxios.request).toHaveBeenCalledTimes(1);
+    expect(response).toBe(true);
+
   });
 });


### PR DESCRIPTION
Enable via `--index-enabled=true` command line argument on AvalancheGo. Once enabled you can fetch tx and vtx on the X-Chain by ID and blocks on the C-Chain and P-Chain also by ID.

This PR included example scripts and tests which demonstrate functionality.

* `X/tx`
  * `index.getLastAccepted`
  * `index.getContainerByIndex`
  * `index.getContainerByID`
  * `index.getContainerRange`
  * `index.getIndex`
  * `index.isAccepted`
* `X/vtx`
  * `index.getLastAccepted`
  * `index.getContainerByIndex`
  * `index.getContainerByID`
  * `index.getContainerRange`
  * `index.getIndex`
  * `index.isAccepted`
* `C/blocks`
  * `index.getLastAccepted`
  * `index.getContainerByIndex`
  * `index.getContainerByID`
  * `index.getContainerRange`
  * `index.getIndex`
  * `index.isAccepted`
* `P/blocks`
  * `index.getLastAccepted`
  * `index.getContainerByIndex`
  * `index.getContainerByID`
  * `index.getContainerRange`
  * `index.getIndex`
  * `index.isAccepted`