### PR TITLE
More updates

### DIFF
--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -33,6 +33,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -43,7 +44,6 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX and ANT")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -87,7 +87,7 @@ const main = async (): Promise<any> => {
   
   const baseTx: BaseTx = new BaseTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -39,7 +39,7 @@ privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -79,7 +79,7 @@ const main = async (): Promise<any> => {
   
   const baseTx: BaseTx = new BaseTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -38,9 +38,9 @@ privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
 // X-local1aekly2mwnsz6lswd6u0jqvd9u6yddt58duwcc9
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
-  
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -51,7 +51,6 @@ const memo: Buffer = Buffer.from("AVM manual create multisig BaseTx to send AVAX
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -39,9 +39,9 @@ privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
 // X-local1aekly2mwnsz6lswd6u0jqvd9u6yddt58duwcc9
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
-  
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -52,7 +52,6 @@ const memo: Buffer = Buffer.from("AVM manual spend multisig BaseTx to send AVAX"
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), [xAddresses[0]], locktime, threshold)

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -40,7 +40,7 @@ privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -84,7 +84,7 @@ const main = async (): Promise<any> => {
   
   const baseTx: BaseTx = new BaseTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -33,6 +33,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -43,7 +44,6 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -72,7 +72,7 @@ const main = async (): Promise<any> => {
 
   const baseTx: BaseTx = new BaseTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -11,7 +11,10 @@ import {
   UnsignedTx,
   Tx
 } from "../../src/apis/avm"
-import { UnixNow } from "../../src/utils"
+import { 
+  UnixNow, 
+  Defaults 
+} from "../../src/utils"
     
 const ip: string = "localhost"
 const port: number = 9650
@@ -24,6 +27,7 @@ const xKeychain: AVMKeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const asOf: BN = UnixNow()
 const threshold: number = 1
 const locktime: BN = new BN(0)
@@ -31,7 +35,6 @@ const memo: Buffer = Buffer.from("AVM utility method buildBaseTx to send AVAX");
 const fee: BN = xchain.getDefaultTxFee()
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)

--- a/examples/avm/buildExportTx-PChain.ts
+++ b/examples/avm/buildExportTx-PChain.ts
@@ -30,6 +30,7 @@ pKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const locktime: BN = new BN(0)
 const asOf: BN = UnixNow()
 const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export AVAX to the P-Chain from the X-Chain")
@@ -38,7 +39,6 @@ const fee: BN = xchain.getDefaultTxFee()
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const amount: BN = balance.sub(fee)

--- a/examples/avm/buildExportTx-cchain-avax.ts
+++ b/examples/avm/buildExportTx-cchain-avax.ts
@@ -36,6 +36,7 @@ cKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const locktime: BN = new BN(0)
 const asOf: BN = UnixNow()
 const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export AVAX to the C-Chain from the X-Chain")
@@ -44,7 +45,6 @@ const fee: BN = xchain.getDefaultTxFee()
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const amount: BN = balance.sub(fee)

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -34,7 +34,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -89,7 +89,7 @@ const main = async (): Promise<any> => {
   
   const createAssetTx: CreateAssetTx = new CreateAssetTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -35,6 +35,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -48,7 +49,6 @@ const denomination: number = 3
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -36,7 +36,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -98,7 +98,7 @@ const main = async (): Promise<any> => {
   
   const createAssetTx: CreateAssetTx = new CreateAssetTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -37,6 +37,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -51,7 +52,6 @@ const groupID: number = 0
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/exportTx-ant-cchain.ts
+++ b/examples/avm/exportTx-ant-cchain.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const exportedOuts: TransferableOutput[] = []
@@ -80,7 +80,7 @@ const main = async (): Promise<any> => {
   
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/exportTx-ant-cchain.ts
+++ b/examples/avm/exportTx-ant-cchain.ts
@@ -34,6 +34,7 @@ const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Export AVAX and ANT from X-Chain to C
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
@@ -57,8 +57,8 @@ const main = async (): Promise<any> => {
     let assetID: Buffer = utxo.getAssetID()
     const outputidx: Buffer = utxo.getOutputIdx()
     let secpTransferOutput: SECPTransferOutput = new SECPTransferOutput()
-    if(avaxAssetID.toString("hex") === assetID.toString("hex")) {
-      assetID = avaxAssetID
+    if(avaxAssetIDBuf.toString("hex") === assetID.toString("hex")) {
+      assetID = avaxAssetIDBuf
       secpTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
     } else {
       secpTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const exportedOuts: TransferableOutput[] = []
@@ -74,7 +74,7 @@ const main = async (): Promise<any> => {
   
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -33,6 +33,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to C-Chain")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -33,6 +33,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
@@ -43,7 +44,6 @@ const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to P-Chain")
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const exportedOuts: TransferableOutput[] = []
@@ -68,7 +68,7 @@ const main = async (): Promise<any> => {
   
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/importTx-cchain.ts
+++ b/examples/avm/importTx-cchain.ts
@@ -33,6 +33,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const importedInputs: TransferableInput[] = []
 const outputs: TransferableOutput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Import AVAX and ANT to the X-Chain fr
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings, cChainBlockchainID)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()

--- a/examples/avm/importTx-cchain.ts
+++ b/examples/avm/importTx-cchain.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const importedInputs: TransferableInput[] = []
@@ -79,7 +79,7 @@ const main = async (): Promise<any> => {
   
   const importTx: ImportTx = new ImportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -32,7 +32,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const importedInputs: TransferableInput[] = []
@@ -70,7 +70,7 @@ const main = async (): Promise<any> => {
   
   const importTx: ImportTx = new ImportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -33,6 +33,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const importedInputs: TransferableInput[] = []
 const outputs: TransferableOutput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Import AVAX to the X-Chain from the P
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings, cChainBlockchainID)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxo: UTXO = utxoSet.getAllUTXOs()[0]

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -48,6 +48,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const operations: TransferableOperation[] = []
@@ -59,7 +60,6 @@ const memo: Buffer = Buffer.from("AVM manual OperationTx to mint an ANT")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -47,7 +47,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -123,7 +123,7 @@ const main = async (): Promise<any> => {
   })
   const operationTx: OperationTx = new OperationTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -50,6 +50,7 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const operations: TransferableOperation[] = []
@@ -63,7 +64,6 @@ const groupID: number = 0
 // const codecID: number = 1    
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -49,7 +49,7 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -126,7 +126,7 @@ const main = async (): Promise<any> => {
   })
   const operationTx: OperationTx = new OperationTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/evm/buildExportTx-xchain-avax.ts
+++ b/examples/evm/buildExportTx-xchain-avax.ts
@@ -20,7 +20,6 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const cchain: EVMAPI = avalanche.CChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: AVMKeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 const cKeychain: EVMKeyChain = cchain.keyChain()
@@ -29,6 +28,7 @@ cKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetId
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
 const Web3 = require('web3');
 const path: string = '/ext/bc/C/rpc'
@@ -36,8 +36,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
           
 const main = async (): Promise<any> => {
-  const avaxAssetIDBuf: Buffer = await xchain.getAVAXAssetID()
-  const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   let balance: BN = await web3.eth.getBalance(cHexAddress)
   const fee: BN = cchain.getDefaultTxFee()
   balance = new BN(balance.toString().substring(0, 17))
@@ -48,7 +46,7 @@ const main = async (): Promise<any> => {
       
   const unsignedTx: UnsignedTx = await cchain.buildExportTx(
     avaxAmount,
-    avaxAssetIDStr,
+    avaxAssetID,
     xChainBlockchainIdStr,
     cHexAddress,
     cAddressStrings[0],

--- a/examples/evm/exportTx-ant-xchain.ts
+++ b/examples/evm/exportTx-ant-xchain.ts
@@ -41,6 +41,7 @@ const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const cChainBlockchainIdStr: string = Defaults.network['12345'].C.blockchainID
 const cChainBlockchainIdBuf: Buffer = bintools.cb58Decode(cChainBlockchainIdStr)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const evmInputs: EVMInput[] = []
 let exportedOuts: TransferableOutput[] = []
 const Web3 = require('web3');
@@ -49,7 +50,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
         
 const main = async (): Promise<any> => {
-  const avaxAssetIDBuf: Buffer = await xchain.getAVAXAssetID()
   const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   const antAssetIDStr: string = "verma4Pa9biWKbjDGNsTXU47cYCyDSNGSU1iBkxucfVSFVXdv"
   const antAssetIDBuf: Buffer = bintools.cb58Decode(antAssetIDStr)

--- a/examples/evm/exportTx-avax-xchain.ts
+++ b/examples/evm/exportTx-avax-xchain.ts
@@ -39,6 +39,7 @@ const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
 const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const cChainBlockchainIdStr: string = Defaults.network['12345'].C.blockchainID
 const cChainBlockchainIdBuf: Buffer = bintools.cb58Decode(cChainBlockchainIdStr)
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetId)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
 const evmInputs: EVMInput[] = []
 const exportedOuts: TransferableOutput[] = []
@@ -48,7 +49,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
         
 const main = async (): Promise<any> => {
-  const avaxAssetIDBuf: Buffer = await xchain.getAVAXAssetID()
   const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   let balance: BN = await web3.eth.getBalance(cHexAddress)
   balance = new BN(balance.toString().substring(0, 17))

--- a/src/apis/evm/importtx.ts
+++ b/src/apis/evm/importtx.ts
@@ -232,15 +232,15 @@ export class ImportTx extends EVMBaseTx {
   private validateOuts(): void {
       // enforce uniqueness of pair(address, assetId) for each out
       const seenAssetSends: Map<string, string[]> = new Map();
-      this.outs.forEach((out: EVMOutput): void => {
-        const address: string = out.getAddressString();
+      this.outs.forEach((evmOutput: EVMOutput): void => {
+        const address: string = evmOutput.getAddressString();
         // TODO - does this need to be error detected? (capital letters)
-        const assetId: string = bintools.cb58Encode(out.getAssetID());
+        const assetId: string = bintools.cb58Encode(evmOutput.getAssetID());
         if(seenAssetSends.has(address)) {
           const assetsSentToAddress: string[] = seenAssetSends.get(address);
           if(assetsSentToAddress.includes(assetId)) {
             // TODO - should the address have error detection?
-            const errorMessage: string = `Error - ImportTx validating Apricot Phase Two rules: duplicate (address, assetId) pair found in outputs: (0x${address}, ${assetId})`;
+            const errorMessage: string = `Error - ImportTx: duplicate (address, assetId) pair found in outputs: (0x${address}, ${assetId})`;
             throw new EVMOutputError(errorMessage);
           }
           assetsSentToAddress.push(assetId);
@@ -265,9 +265,9 @@ export class ImportTx extends EVMBaseTx {
         }
       });
       // subtract all outgoing AVAX
-      this.outs.forEach((output: EVMOutput): void => {
-        if(avaxAssetID === bintools.cb58Encode(output.getAssetID())) {
-          feeDiff.isub(output.getAmount());
+      this.outs.forEach((evmOutput: EVMOutput): void => {
+        if(avaxAssetID === bintools.cb58Encode(evmOutput.getAssetID())) {
+          feeDiff.isub(evmOutput.getAmount());
         }
       });
       if(feeDiff.lt(requiredFee)) {


### PR DESCRIPTION
* Now that the AVAX AssetId is a constant we can remove these `async` calls
* Formatting to use `fooID` instead of `fooid` or `fooId`