### PR TITLE
v3.4.0-RC.3

### DIFF
--- a/examples/admin/alias.ts
+++ b/examples/admin/alias.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
   
 const main = async (): Promise<any> => {
-  const endpoint: string = "/ext/bc/X";
-  const alias: string = "xchain";
-  const successful: boolean = await admin.alias(endpoint, alias);
-  console.log(successful);
+  const endpoint: string = "/ext/bc/X"
+  const alias: string = "xchain"
+  const successful: boolean = await admin.alias(endpoint, alias)
+  console.log(successful)
 }
     
 main()

--- a/examples/admin/aliasChain.ts
+++ b/examples/admin/aliasChain.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
   
 const main = async (): Promise<any> => {
-  const blockchain: string = "X";
-  const alias: string = "xchain";
-  const successful: boolean = await admin.aliasChain(blockchain, alias);
-  console.log(successful);
+  const blockchain: string = "X"
+  const alias: string = "xchain"
+  const successful: boolean = await admin.aliasChain(blockchain, alias)
+  console.log(successful)
 }
     
 main()

--- a/examples/admin/getChainAliases.ts
+++ b/examples/admin/getChainAliases.ts
@@ -1,19 +1,19 @@
 import {
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
 
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const blockchain: string = "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed";
-  const aliases: string[] = await admin.getChainAliases(blockchain);
-  console.log(aliases);
+  const blockchain: string = "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed"
+  const aliases: string[] = await admin.getChainAliases(blockchain)
+  console.log(aliases)
 }
 
 main()

--- a/examples/admin/lockProfile.ts
+++ b/examples/admin/lockProfile.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
   
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.lockProfile();
-  console.log(successful);
+  const successful: boolean = await admin.lockProfile()
+  console.log(successful)
 }
     
 main()

--- a/examples/admin/memoryProfile.ts
+++ b/examples/admin/memoryProfile.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
   
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.memoryProfile();
-  console.log(successful);
+  const successful: boolean = await admin.memoryProfile()
+  console.log(successful)
 }
     
 main()

--- a/examples/admin/startCPUProfiler.ts
+++ b/examples/admin/startCPUProfiler.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
   
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.startCPUProfiler();
-  console.log(successful);
+  const successful: boolean = await admin.startCPUProfiler()
+  console.log(successful)
 }
     
 main()

--- a/examples/admin/stopCPUProfiler.ts
+++ b/examples/admin/stopCPUProfiler.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AdminAPI } from "../../dist/apis/admin";
+} from "../../dist"
+import { AdminAPI } from "../../dist/apis/admin"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const admin: AdminAPI = avalanche.Admin();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const admin: AdminAPI = avalanche.Admin()
   
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.stopCPUProfiler();
-  console.log(successful);
+  const successful: boolean = await admin.stopCPUProfiler()
+  console.log(successful)
 }
     
 main()

--- a/examples/auth/changePassword.ts
+++ b/examples/auth/changePassword.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AuthAPI } from "../../dist/apis/auth";
+} from "../../dist"
+import { AuthAPI } from "../../dist/apis/auth"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const auth: AuthAPI = avalanche.Auth();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const auth: AuthAPI = avalanche.Auth()
   
 const main = async (): Promise<any> => {
-  const oldPassword: string = "R1oJgqud0GGqe9nhip49N";
-  const newPassword: string = "24j39CUm0URaquSo3bI69";
-  const successful: boolean = await auth.changePassword(oldPassword, newPassword);
-  console.log(successful);
+  const oldPassword: string = "R1oJgqud0GGqe9nhip49N"
+  const newPassword: string = "24j39CUm0URaquSo3bI69"
+  const successful: boolean = await auth.changePassword(oldPassword, newPassword)
+  console.log(successful)
 }
     
 main()

--- a/examples/auth/newToken.ts
+++ b/examples/auth/newToken.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AuthAPI } from "../../dist/apis/auth";
+} from "../../dist"
+import { AuthAPI } from "../../dist/apis/auth"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const auth: AuthAPI = avalanche.Auth();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const auth: AuthAPI = avalanche.Auth()
   
 const main = async (): Promise<any> => {
-  const password: string = "R1oJgqud0GGqe9nhip49N";
-  const endpoints: string[] = ["*"];
-  const token: string = await auth.newToken(password, endpoints);
-  console.log(token);
+  const password: string = "R1oJgqud0GGqe9nhip49N"
+  const endpoints: string[] = ["*"]
+  const token: string = await auth.newToken(password, endpoints)
+  console.log(token)
 }
     
 main()

--- a/examples/auth/revokeToken.ts
+++ b/examples/auth/revokeToken.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AuthAPI } from "../../dist/apis/auth";
+} from "../../dist"
+import { AuthAPI } from "../../dist/apis/auth"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const auth: AuthAPI = avalanche.Auth();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const auth: AuthAPI = avalanche.Auth()
   
 const main = async (): Promise<any> => {
-  const password: string = "R1oJgqud0GGqe9nhip49N";
+  const password: string = "R1oJgqud0GGqe9nhip49N"
   const token: string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MTE3MDkyMzMsIkVuZHBvaW50cyI6WyIqIl19.dvAcU0BmPzzy9lEA1wXb7rdPFN2ykayefxYc0aecH10"
-  const successful: boolean = await auth.revokeToken(password, token);
-  console.log(successful);
+  const successful: boolean = await auth.revokeToken(password, token)
+  console.log(successful)
 }
     
 main()

--- a/examples/avm/addressFromBuffer.ts
+++ b/examples/avm/addressFromBuffer.ts
@@ -1,21 +1,20 @@
 import { 
   Avalanche,
   Buffer
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-
-  const addressBuffer: Buffer = Buffer.from("3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c");
-  const addressString: string = await xchain.addressFromBuffer(addressBuffer);
-  console.log(addressString);
+  const addressBuffer: Buffer = Buffer.from("3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c")
+  const addressString: string = xchain.addressFromBuffer(addressBuffer)
+  console.log(addressString)
 }
     
 main()

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -32,7 +32,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -43,7 +44,6 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX and ANT")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
@@ -87,7 +87,7 @@ const main = async (): Promise<any> => {
   
   const baseTx: BaseTx = new BaseTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -54,7 +54,7 @@ const main = async (): Promise<any> => {
       const amt: BN = amountOutput.getAmount().clone()
       const txid: Buffer = utxo.getTxID()
       const outputidx: Buffer = utxo.getOutputIdx()
-      const assetID: Buffer = utxo.getAssetID();
+      const assetID: Buffer = utxo.getAssetID()
   
       if(assetID.toString('hex') === avaxAssetIDBuf.toString('hex')) {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -33,7 +33,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -55,18 +56,18 @@ const main = async (): Promise<any> => {
       const outputidx: Buffer = utxo.getOutputIdx()
       const assetID: Buffer = utxo.getAssetID();
   
-      if(assetID.toString('hex') === avaxAssetID.toString('hex')) {
+      if(assetID.toString('hex') === avaxAssetIDBuf.toString('hex')) {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
         // Uncomment for codecID 00 01
         // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+        const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
         outputs.push(transferableOutput)
   
         const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
         // Uncomment for codecID 00 01
         // secpTransferInput.setCodecID(codecID)
         secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+        const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
         inputs.push(input)
       } else {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 let privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 // X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u
 xKeychain.importKey(privKey)

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -40,7 +40,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -51,12 +52,12 @@ const memo: Buffer = Buffer.from("AVM manual create multisig BaseTx to send AVAX
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
   // Uncomment for codecID 00 01
 //   secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   outputs.push(transferableOutput)
   
   const avmUTXOResponse: any= await xchain.getUTXOs(xAddressStrings)
@@ -73,7 +74,7 @@ const main = async (): Promise<any> => {
     // secpTransferInput.setCodecID(codecID)
     secpTransferInput.addSignatureIdx(0, xAddresses[0])
   
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
   })
   

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -38,9 +38,9 @@ privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
 // X-local1aekly2mwnsz6lswd6u0jqvd9u6yddt58duwcc9
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
-  
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -51,7 +51,6 @@ const memo: Buffer = Buffer.from("AVM manual create multisig BaseTx to send AVAX
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
@@ -80,7 +79,7 @@ const main = async (): Promise<any> => {
   
   const baseTx: BaseTx = new BaseTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -39,9 +39,9 @@ privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
 // X-local1aekly2mwnsz6lswd6u0jqvd9u6yddt58duwcc9
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
-  
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -52,7 +52,6 @@ const memo: Buffer = Buffer.from("AVM manual spend multisig BaseTx to send AVAX"
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), [xAddresses[0]], locktime, threshold)
@@ -85,7 +84,7 @@ const main = async (): Promise<any> => {
   
   const baseTx: BaseTx = new BaseTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -41,7 +41,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -52,12 +53,12 @@ const memo: Buffer = Buffer.from("AVM manual spend multisig BaseTx to send AVAX"
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), [xAddresses[0]], locktime, threshold)
   // Uncomment for codecID 00 01
 //   secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   outputs.push(transferableOutput)
   
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
@@ -78,7 +79,7 @@ const main = async (): Promise<any> => {
     }
     })
   
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
   })
   

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -20,7 +20,6 @@ import {
 } from "../../src/apis/avm"
 import { Defaults } from "../../src/utils"
       
-      
 const ip: string = "localhost"
 const port: number = 9650
 const protocol: string = "http"
@@ -28,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 let privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 // X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u
 xKeychain.importKey(privKey)

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -32,7 +32,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -43,7 +44,6 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
@@ -72,7 +72,7 @@ const main = async (): Promise<any> => {
 
   const baseTx: BaseTx = new BaseTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -33,7 +33,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -44,12 +45,12 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse['balance'])
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
   // Uncomment for codecID 00 01
   // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   outputs.push(transferableOutput)
 
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
@@ -66,7 +67,7 @@ const main = async (): Promise<any> => {
     // secpTransferInput.setCodecID(codecID)
     secpTransferInput.addSignatureIdx(0, xAddresses[0])
 
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
   })
 

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src"
 import {
   AVMAPI,
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/buildBaseTx-ant.ts
+++ b/examples/avm/buildBaseTx-ant.ts
@@ -1,12 +1,11 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
@@ -19,7 +18,7 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -1,12 +1,11 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
@@ -22,8 +21,7 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
-const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
@@ -31,7 +29,7 @@ const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const asOf: BN = UnixNow()
 const threshold: number = 1
 const locktime: BN = new BN(0)
-const memo: Buffer = Buffer.from("AVM utility method buildBaseTx to send AVAX");
+const memo: Buffer = Buffer.from("AVM utility method buildBaseTx to send AVAX")
 const fee: BN = xchain.getDefaultTxFee()
       
 const main = async (): Promise<any> => {

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -27,7 +27,7 @@ const xKeychain: AVMKeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const asOf: BN = UnixNow()
 const threshold: number = 1
 const locktime: BN = new BN(0)
@@ -35,7 +35,7 @@ const memo: Buffer = Buffer.from("AVM utility method buildBaseTx to send AVAX");
 const fee: BN = xchain.getDefaultTxFee()
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse.balance)
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -11,7 +11,10 @@ import {
   UnsignedTx,
   Tx
 } from "../../src/apis/avm"
-import { UnixNow } from "../../src/utils"
+import { 
+  UnixNow, 
+  Defaults 
+} from "../../src/utils"
     
 const ip: string = "localhost"
 const port: number = 9650
@@ -24,6 +27,7 @@ const xKeychain: AVMKeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const asOf: BN = UnixNow()
 const threshold: number = 1
 const locktime: BN = new BN(0)
@@ -31,7 +35,6 @@ const memo: Buffer = Buffer.from("AVM utility method buildBaseTx to send AVAX");
 const fee: BN = xchain.getDefaultTxFee()
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)

--- a/examples/avm/buildCreateAssetTx.ts
+++ b/examples/avm/buildCreateAssetTx.ts
@@ -1,9 +1,8 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain,
@@ -21,7 +20,6 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)

--- a/examples/avm/buildCreateNFTAssetTx.ts
+++ b/examples/avm/buildCreateNFTAssetTx.ts
@@ -20,7 +20,6 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: AVMKeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)

--- a/examples/avm/buildCreateNFTAssetTx.ts
+++ b/examples/avm/buildCreateNFTAssetTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain as AVMKeyChain,

--- a/examples/avm/buildCreateNFTMintTx.ts
+++ b/examples/avm/buildCreateNFTMintTx.ts
@@ -13,7 +13,7 @@ import {
   AVMConstants,
   UTXO
 } from "../../src/apis/avm"
-import { OutputOwners } from "../../src/common";
+import { OutputOwners } from "../../src/common"
 import { UnixNow } from "../../src/utils"
       
 const getUTXOIDs = (utxoSet: UTXOSet, txid: string, outputType: number = AVMConstants.SECPXFEROUTPUTID_CODECONE, assetID = "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"): string[] => {

--- a/examples/avm/buildCreateNFTMintTx.ts
+++ b/examples/avm/buildCreateNFTMintTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain,

--- a/examples/avm/buildExportTx-PChain.ts
+++ b/examples/avm/buildExportTx-PChain.ts
@@ -1,6 +1,5 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
 } from "../../src";
@@ -21,7 +20,6 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: AVMKeyChain = xchain.keyChain()
 const pKeychain: KeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
@@ -30,7 +28,7 @@ pKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const locktime: BN = new BN(0)
 const asOf: BN = UnixNow()
 const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export AVAX to the P-Chain from the X-Chain")
@@ -39,7 +37,7 @@ const fee: BN = xchain.getDefaultTxFee()
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse.balance)
   const amount: BN = balance.sub(fee)
     

--- a/examples/avm/buildExportTx-PChain.ts
+++ b/examples/avm/buildExportTx-PChain.ts
@@ -30,6 +30,7 @@ pKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const locktime: BN = new BN(0)
 const asOf: BN = UnixNow()
 const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export AVAX to the P-Chain from the X-Chain")
@@ -38,7 +39,6 @@ const fee: BN = xchain.getDefaultTxFee()
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const amount: BN = balance.sub(fee)

--- a/examples/avm/buildExportTx-PChain.ts
+++ b/examples/avm/buildExportTx-PChain.ts
@@ -2,7 +2,7 @@ import {
   Avalanche,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain as AVMKeyChain,
@@ -10,8 +10,14 @@ import {
   UnsignedTx,
   Tx
 } from "../../src/apis/avm"
-import { KeyChain, PlatformVMAPI } from "../../src/apis/platformvm";
-import { Defaults, UnixNow } from "../../src/utils"
+import { 
+  KeyChain as PlatformVMKeyChain, 
+  PlatformVMAPI 
+} from "../../src/apis/platformvm"
+import { 
+  Defaults, 
+  UnixNow 
+} from "../../src/utils"
         
 const ip: string = "localhost"
 const port: number = 9650
@@ -21,7 +27,7 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const pchain: PlatformVMAPI = avalanche.PChain()
 const xKeychain: AVMKeyChain = xchain.keyChain()
-const pKeychain: KeyChain = pchain.keyChain()
+const pKeychain: PlatformVMKeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 pKeychain.importKey(privKey)

--- a/examples/avm/buildExportTx-cchain-ant.ts
+++ b/examples/avm/buildExportTx-cchain-ant.ts
@@ -41,9 +41,9 @@ const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export ANT
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const amount: BN = new BN(500)
+  const amount: BN = new BN(350)
   const threshold: number = 1
-  const assetID: string = "2DLukZZms6BdwsUea4DtWHReGa6reRw3QWGJfC7z5p7tqHCSxK"
+  const assetID: string = "2HgQ12Akkpht8vX9RGuGMTvPXhBnGuaSTQncxWCw22NXkxuaKn"
     
   const unsignedTx: UnsignedTx = await xchain.buildExportTx(
     utxoSet,

--- a/examples/avm/buildExportTx-cchain-ant.ts
+++ b/examples/avm/buildExportTx-cchain-ant.ts
@@ -2,7 +2,7 @@ import {
   Avalanche,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain as AVMKeyChain,
@@ -13,7 +13,7 @@ import {
 import { 
   KeyChain as EVMKeyChain, 
   EVMAPI 
-} from "../../src/apis/evm";
+} from "../../src/apis/evm"
 import { 
   Defaults, 
   UnixNow 

--- a/examples/avm/buildExportTx-cchain-avax.ts
+++ b/examples/avm/buildExportTx-cchain-avax.ts
@@ -1,9 +1,8 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain as AVMKeyChain,
@@ -14,7 +13,7 @@ import {
 import { 
   KeyChain as EVMKeyChain, 
   EVMAPI 
-} from "../../src/apis/evm";
+} from "../../src/apis/evm"
 import { 
   Defaults, 
   UnixNow 
@@ -27,7 +26,6 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const cchain: EVMAPI = avalanche.CChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: AVMKeyChain = xchain.keyChain()
 const cKeychain: EVMKeyChain = cchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"

--- a/examples/avm/buildExportTx-cchain-avax.ts
+++ b/examples/avm/buildExportTx-cchain-avax.ts
@@ -36,6 +36,7 @@ cKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const locktime: BN = new BN(0)
 const asOf: BN = UnixNow()
 const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export AVAX to the C-Chain from the X-Chain")
@@ -44,7 +45,6 @@ const fee: BN = xchain.getDefaultTxFee()
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const amount: BN = balance.sub(fee)

--- a/examples/avm/buildExportTx-cchain-avax.ts
+++ b/examples/avm/buildExportTx-cchain-avax.ts
@@ -36,7 +36,7 @@ cKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const locktime: BN = new BN(0)
 const asOf: BN = UnixNow()
 const memo: Buffer = Buffer.from("AVM utility method buildExportTx to export AVAX to the C-Chain from the X-Chain")
@@ -45,7 +45,7 @@ const fee: BN = xchain.getDefaultTxFee()
 const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse.balance)
   const amount: BN = balance.sub(fee)
     

--- a/examples/avm/buildImportTx-PChain.ts
+++ b/examples/avm/buildImportTx-PChain.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain,
@@ -11,7 +11,10 @@ import {
   UnsignedTx,
   Tx
 } from "../../src/apis/avm"
-import { Defaults, UnixNow } from "../../src/utils"
+import { 
+  Defaults, 
+  UnixNow 
+} from "../../src/utils"
         
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildImportTx-cchain.ts
+++ b/examples/avm/buildImportTx-cchain.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain,
@@ -11,7 +11,10 @@ import {
   UnsignedTx,
   Tx
 } from "../../src/apis/avm"
-import { Defaults, UnixNow } from "../../src/utils"
+import { 
+  Defaults, 
+  UnixNow 
+} from "../../src/utils"
         
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildNFTTransferTx.ts
+++ b/examples/avm/buildNFTTransferTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain,

--- a/examples/avm/buildSECPMintTx.ts
+++ b/examples/avm/buildSECPMintTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain,
@@ -15,7 +15,7 @@ import {
   SECPTransferOutput,
   UTXO
 } from "../../src/apis/avm"
-import { UnixNow } from "../../src/utils";
+import { UnixNow } from "../../src/utils"
   
 const getUTXOIDs = (utxoSet: UTXOSet, txid: string, outputType: number = AVMConstants.SECPXFEROUTPUTID_CODECONE, assetID = "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"): string[] => {
   const utxoids: string[] = utxoSet.getUTXOIDs()

--- a/examples/avm/createAddress.ts
+++ b/examples/avm/createAddress.ts
@@ -4,9 +4,9 @@ import {
 import { AVMAPI } from "../../dist/apis/avm"
   
 const ip: string = 'localhost'
-const port: number = 9650;
+const port: number = 9650
 const protocol: string = 'http'
-const networkID: number = 12345;
+const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
  

--- a/examples/avm/createAddress.ts
+++ b/examples/avm/createAddress.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
+const ip: string = 'localhost'
 const port: number = 9650;
-const protocol: string = 'http';
+const protocol: string = 'http'
 const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
-  
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
+ 
 const main = async (): Promise<any> => {
-  const username: string = "username";
+  const username: string = "username"
   const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const address: string = await xchain.createAddress(username, password);
-  console.log(address);
+  const address: string = await xchain.createAddress(username, password)
+  console.log(address)
 }
     
 main()

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -34,7 +34,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -48,7 +49,6 @@ const denomination: number = 3
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
@@ -89,7 +89,7 @@ const main = async (): Promise<any> => {
   
   const createAssetTx: CreateAssetTx = new CreateAssetTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -35,7 +35,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -49,12 +50,12 @@ const denomination: number = 3
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
   // Uncomment for codecID 00 01
   // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   outputs.push(transferableOutput)
   
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
@@ -71,7 +72,7 @@ const main = async (): Promise<any> => {
     // secpTransferInput.setCodecID(codecID)
     secpTransferInput.addSignatureIdx(0, xAddresses[0])
   
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
   })
   

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
   KeyChain as AVMKeyChain,

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -31,7 +31,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -37,7 +37,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -52,12 +53,12 @@ const groupID: number = 0
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], (avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
   // Uncomment for codecID 00 01
 //   secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   outputs.push(transferableOutput)
   
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
@@ -66,7 +67,7 @@ const main = async (): Promise<any> => {
   utxos.forEach((utxo: UTXO): void => {
     const outputID: number = utxo.getOutput().getTypeID() 
     const assetID: Buffer = utxo.getAssetID()
-    if(outputID === 7 && assetID.toString("hex") === avaxAssetID.toString("hex")) {
+    if(outputID === 7 && assetID.toString("hex") === avaxAssetIDBuf.toString("hex")) {
     const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
     const amt: BN = amountOutput.getAmount().clone()
     const txid: Buffer = utxo.getTxID()
@@ -77,7 +78,7 @@ const main = async (): Promise<any> => {
     // secpTransferInput.setCodecID(codecID)
     secpTransferInput.addSignatureIdx(0, xAddresses[0])
   
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
     }
   })

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -36,7 +36,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = xchain.getDefaultTxFee()
@@ -51,7 +52,6 @@ const groupID: number = 0
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
@@ -98,7 +98,7 @@ const main = async (): Promise<any> => {
   
   const createAssetTx: CreateAssetTx = new CreateAssetTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/exportTx-ant-cchain.ts
+++ b/examples/avm/exportTx-ant-cchain.ts
@@ -32,8 +32,9 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Export AVAX and ANT from X-Chain to C
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
@@ -57,8 +57,8 @@ const main = async (): Promise<any> => {
     let assetID: Buffer = utxo.getAssetID()
     const outputidx: Buffer = utxo.getOutputIdx()
     let secpTransferOutput: SECPTransferOutput = new SECPTransferOutput()
-    if(avaxAssetID.toString("hex") === assetID.toString("hex")) {
-      assetID = avaxAssetID
+    if(avaxAssetIDBuf.toString("hex") === assetID.toString("hex")) {
+      assetID = avaxAssetIDBuf
       secpTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
     } else {
       secpTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)
@@ -80,7 +80,7 @@ const main = async (): Promise<any> => {
   
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/exportTx-ant-cchain.ts
+++ b/examples/avm/exportTx-ant-cchain.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/exportTx-ant-cchain.ts
+++ b/examples/avm/exportTx-ant-cchain.ts
@@ -34,7 +34,8 @@ const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
-const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
@@ -58,7 +59,6 @@ const main = async (): Promise<any> => {
     const outputidx: Buffer = utxo.getOutputIdx()
     let secpTransferOutput: SECPTransferOutput = new SECPTransferOutput()
     if(avaxAssetIDBuf.toString("hex") === assetID.toString("hex")) {
-      assetID = avaxAssetIDBuf
       secpTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
     } else {
       secpTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -33,7 +33,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
@@ -46,12 +47,12 @@ const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to C-Chain")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
   // Uncomment for codecID 00 01
   // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   exportedOuts.push(transferableOutput)
   
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
@@ -68,7 +69,7 @@ const main = async (): Promise<any> => {
     // Uncomment for codecID 00 01
     // secpTransferOutput.setCodecID(codecID)
   
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
   })
   

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -32,7 +32,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to C-Chain")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
@@ -74,7 +74,7 @@ const main = async (): Promise<any> => {
   
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -32,7 +32,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
@@ -43,7 +44,6 @@ const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to P-Chain")
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
@@ -68,7 +68,7 @@ const main = async (): Promise<any> => {
   
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -33,7 +33,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const pChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
@@ -44,10 +45,10 @@ const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to P-Chain")
       
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], bintools.cb58Encode(avaxAssetID))
+  const getBalanceResponse: any = await xchain.getBalance(xAddressStrings[0], avaxAssetID)
   const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(balance.sub(fee), xAddresses, locktime, threshold)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   exportedOuts.push(transferableOutput)
   
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
@@ -62,7 +63,7 @@ const main = async (): Promise<any> => {
     const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
     secpTransferInput.addSignatureIdx(0, xAddresses[0])
   
-    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+    const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
     inputs.push(input)
   })
   

--- a/examples/avm/getAVAXAssetID.ts
+++ b/examples/avm/getAVAXAssetID.ts
@@ -1,20 +1,19 @@
 import { 
   Avalanche,
   Buffer
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-
-  const assetID: Buffer = await xchain.getAVAXAssetID();
-  console.log(assetID);
+  const assetID: Buffer = await xchain.getAVAXAssetID()
+  console.log(assetID)
 }
     
 main()

--- a/examples/avm/getAllBalances.ts
+++ b/examples/avm/getAllBalances.ts
@@ -11,7 +11,7 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
+  const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
   const balances: object[] = await xchain.getAllBalances(address)
   console.log(balances)
 }

--- a/examples/avm/getAllBalances.ts
+++ b/examples/avm/getAllBalances.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
   const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
-  const balances: object[] = await xchain.getAllBalances(address);
-  console.log(balances);
+  const balances: object[] = await xchain.getAllBalances(address)
+  console.log(balances)
 }
     
 main()

--- a/examples/avm/getAssetDescription.ts
+++ b/examples/avm/getAssetDescription.ts
@@ -6,7 +6,7 @@ import { AVMAPI } from "../../dist/apis/avm"
 const ip: string = 'localhost'
 const port: number = 9650
 const protocol: string = 'http'
-const networkID: number = 12345;
+const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
   

--- a/examples/avm/getAssetDescription.ts
+++ b/examples/avm/getAssetDescription.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
 const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const assetDescription: any = await xchain.getAssetDescription("AVAX");
-  console.log(assetDescription);
+  const assetDescription: any = await xchain.getAssetDescription("AVAX")
+  console.log(assetDescription)
 }
     
 main()

--- a/examples/avm/getBalance.ts
+++ b/examples/avm/getBalance.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
-  const balance: object = await xchain.getBalance(address, "AVAX");
-  console.log(balance);
+  const address: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+  const balance: object = await xchain.getBalance(address, "AVAX")
+  console.log(balance)
 }
     
 main()

--- a/examples/avm/getBlockchainAlias.ts
+++ b/examples/avm/getBlockchainAlias.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const alias: string = await xchain.getBlockchainAlias();
-  console.log(alias);
+  const alias: string = await xchain.getBlockchainAlias()
+  console.log(alias)
 }
     
 main()

--- a/examples/avm/getBlockchainID.ts
+++ b/examples/avm/getBlockchainID.ts
@@ -1,17 +1,17 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const blockchainID: string = await xchain.getBlockchainID();
+  const blockchainID: string = xchain.getBlockchainID()
   console.log(blockchainID);
 }
     

--- a/examples/avm/getBlockchainID.ts
+++ b/examples/avm/getBlockchainID.ts
@@ -12,7 +12,7 @@ const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
   const blockchainID: string = xchain.getBlockchainID()
-  console.log(blockchainID);
+  console.log(blockchainID)
 }
     
 main()

--- a/examples/avm/getCreationTxFee.ts
+++ b/examples/avm/getCreationTxFee.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche,
   BN
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const txFee: BN = await xchain.getCreationTxFee();
-  console.log(txFee);
+  const txFee: BN = xchain.getCreationTxFee()
+  console.log(txFee)
 }
     
 main()

--- a/examples/avm/getDefaultCreationTxFee.ts
+++ b/examples/avm/getDefaultCreationTxFee.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche,
   BN
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const txFee: BN = await xchain.getDefaultCreationTxFee();
-  console.log(txFee);
+  const txFee: BN = xchain.getDefaultCreationTxFee()
+  console.log(txFee)
 }
     
 main()

--- a/examples/avm/getDefaultTxFee.ts
+++ b/examples/avm/getDefaultTxFee.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche,
   BN
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const defaultTxFee: BN = await xchain.getDefaultTxFee();
-  console.log(defaultTxFee);
+  const defaultTxFee: BN = xchain.getDefaultTxFee()
+  console.log(defaultTxFee)
 }
     
 main()

--- a/examples/avm/getTx.ts
+++ b/examples/avm/getTx.ts
@@ -1,17 +1,17 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const tx: string = await xchain.getTx("2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D");
+  const tx: string = await xchain.getTx("2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D")
   console.log(tx)
 }
 

--- a/examples/avm/getTxFee.ts
+++ b/examples/avm/getTxFee.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche,
   BN
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const txFee: BN = await xchain.getTxFee();
-  console.log(txFee);
+  const txFee: BN = await xchain.getTxFee()
+  console.log(txFee)
 }
     
 main()

--- a/examples/avm/getTxStatus.ts
+++ b/examples/avm/getTxStatus.ts
@@ -6,7 +6,7 @@ import { AVMAPI } from "../../dist/apis/avm"
 const ip: string = 'localhost'
 const port: number = 9650
 const protocol: string = 'http'
-const networkID: number = 12345;
+const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
   

--- a/examples/avm/getTxStatus.ts
+++ b/examples/avm/getTxStatus.ts
@@ -1,17 +1,17 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
 const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const status: string = await xchain.getTxStatus("2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D");
+  const status: string = await xchain.getTxStatus("2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D")
   console.log(status)
 }
 

--- a/examples/avm/importTx-cchain.ts
+++ b/examples/avm/importTx-cchain.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/importTx-cchain.ts
+++ b/examples/avm/importTx-cchain.ts
@@ -32,7 +32,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const importedInputs: TransferableInput[] = []
 const outputs: TransferableOutput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Import AVAX and ANT to the X-Chain fr
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings, cChainBlockchainID)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
@@ -79,7 +79,7 @@ const main = async (): Promise<any> => {
   
   const importTx: ImportTx = new ImportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/importTx-cchain.ts
+++ b/examples/avm/importTx-cchain.ts
@@ -33,7 +33,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const cChainBlockchainID: string = Defaults.network['12345'].C.blockchainID
 const importedInputs: TransferableInput[] = []
 const outputs: TransferableOutput[] = []
@@ -56,8 +57,7 @@ const main = async (): Promise<any> => {
     let assetID: Buffer = utxo.getAssetID()
     const outputidx: Buffer = utxo.getOutputIdx()
     let secpTransferOutput: SECPTransferOutput = new SECPTransferOutput()
-    if(avaxAssetID.toString("hex") === assetID.toString("hex")) {
-      assetID = avaxAssetID
+    if(avaxAssetIDBuf.toString("hex") === assetID.toString("hex")) {
       secpTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
     } else {
       secpTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -27,7 +27,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -33,7 +33,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const cChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const importedInputs: TransferableInput[] = []
 const outputs: TransferableOutput[] = []
@@ -59,13 +60,13 @@ const main = async (): Promise<any> => {
   // Uncomment for codecID 00 01
   // secpTransferInput.setCodecID(codecID)
   
-  const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+  const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
   importedInputs.push(input)
   
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
   // Uncomment for codecID 00 01
   // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+  const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
   outputs.push(transferableOutput)
   
   const importTx: ImportTx = new ImportTx(

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -32,7 +32,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const cChainBlockchainID: string = Defaults.network['12345'].P.blockchainID
 const importedInputs: TransferableInput[] = []
 const outputs: TransferableOutput[] = []
@@ -45,7 +46,6 @@ const memo: Buffer = Buffer.from("Manually Import AVAX to the X-Chain from the P
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings, cChainBlockchainID)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxo: UTXO = utxoSet.getAllUTXOs()[0]
@@ -70,7 +70,7 @@ const main = async (): Promise<any> => {
   
   const importTx: ImportTx = new ImportTx(
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/keyChain.ts
+++ b/examples/avm/keyChain.ts
@@ -1,18 +1,21 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI, KeyChain } from "../../dist/apis/avm";
+} from "../../dist"
+import { 
+  AVMAPI, 
+  KeyChain 
+} from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const keyChain: KeyChain = await xchain.keyChain();
-  console.log(keyChain);
+  const keyChain: KeyChain = xchain.keyChain()
+  console.log(keyChain)
 }
     
 main()

--- a/examples/avm/listAddresses.ts
+++ b/examples/avm/listAddresses.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const username: string = "username";
+  const username: string = "username"
   const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const addresses: string[] = await xchain.listAddresses(username, password);
-  console.log(addresses);
+  const addresses: string[] = await xchain.listAddresses(username, password)
+  console.log(addresses)
 }
     
 main()

--- a/examples/avm/newKeyChain.ts
+++ b/examples/avm/newKeyChain.ts
@@ -1,18 +1,21 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI, KeyChain } from "../../dist/apis/avm";
+} from "../../dist"
+import { 
+  AVMAPI, 
+  KeyChain 
+} from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const keyChain: KeyChain = await xchain.newKeyChain();
-  console.log(keyChain);
+  const keyChain: KeyChain = xchain.newKeyChain()
+  console.log(keyChain)
 }
     
 main()

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -3,10 +3,10 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
+  KeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -42,7 +42,7 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const xKeychain: KeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -64,10 +64,10 @@ const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
+  utxos.forEach((utxo: UTXO): void => {
     const txid: Buffer = utxo.getTxID()
     const outputidx: Buffer = utxo.getOutputIdx()
-    const assetID: Buffer = utxo.getAssetID();
+    const assetID: Buffer = utxo.getAssetID()
     if(utxo.getOutput().getTypeID() != 6) {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -48,7 +48,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const operations: TransferableOperation[] = []
@@ -71,18 +72,18 @@ const main = async (): Promise<any> => {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()
   
-      if(assetID.toString('hex') === avaxAssetID.toString('hex')) {
+      if(assetID.toString('hex') === avaxAssetIDBuf.toString('hex')) {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
         // Uncomment for codecID 00 01
         // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+        const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
         outputs.push(transferableOutput)
     
         const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
         // Uncomment for codecID 00 01
         // secpTransferInput.setCodecID(codecID)
         secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+        const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
         inputs.push(input)
       } else {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -47,7 +47,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const operations: TransferableOperation[] = []
@@ -59,7 +60,6 @@ const memo: Buffer = Buffer.from("AVM manual OperationTx to mint an ANT")
 // const codecID: number = 1
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
@@ -123,7 +123,7 @@ const main = async (): Promise<any> => {
   })
   const operationTx: OperationTx = new OperationTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -50,7 +50,8 @@ xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const blockchainID: string = Defaults.network['12345'].X.blockchainID
-const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const operations: TransferableOperation[] = []
@@ -75,18 +76,18 @@ const main = async (): Promise<any> => {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()
   
-      if(assetID.toString('hex') === avaxAssetID.toString('hex')) {
+      if(assetID.toString('hex') === avaxAssetIDBuf.toString('hex')) {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt.sub(fee), xAddresses, locktime, threshold)
         // Uncomment for codecID 00 01
         // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetID, secpTransferOutput)
+        const transferableOutput: TransferableOutput = new TransferableOutput(avaxAssetIDBuf, secpTransferOutput)
         outputs.push(transferableOutput)
     
         const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
         // Uncomment for codecID 00 01
         // secpTransferInput.setCodecID(codecID)
         secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetID, secpTransferInput)
+        const input: TransferableInput = new TransferableInput(txid, outputidx, avaxAssetIDBuf, secpTransferInput)
         inputs.push(input)
       } else {
         const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(amt, xAddresses, locktime, threshold)

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -67,10 +67,10 @@ const main = async (): Promise<any> => {
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO, index: number) => {
+  utxos.forEach((utxo: UTXO): void => {
     const txid: Buffer = utxo.getTxID()
     const outputidx: Buffer = utxo.getOutputIdx()
-    const assetID: Buffer = utxo.getAssetID();
+    const assetID: Buffer = utxo.getAssetID()
     if(utxo.getOutput().getTypeID() != 10 && utxo.getOutput().getTypeID() != 11) {
       const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
       const amt: BN = amountOutput.getAmount().clone()

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -49,7 +49,8 @@ const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUr
 xKeychain.importKey(privKey)
 const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
-const blockchainid: string = Defaults.network['12345'].X.blockchainID
+const blockchainID: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const operations: TransferableOperation[] = []
@@ -63,7 +64,6 @@ const groupID: number = 0
 // const codecID: number = 1    
       
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await xchain.getAVAXAssetID()
   const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
   const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
@@ -126,7 +126,7 @@ const main = async (): Promise<any> => {
   })
   const operationTx: OperationTx = new OperationTx (
     networkID,
-    bintools.cb58Decode(blockchainid),
+    bintools.cb58Decode(blockchainID),
     outputs,
     inputs,
     memo,

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -3,10 +3,9 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   AVMAPI, 
-  KeyChain as AVMKeyChain,
   SECPTransferOutput,
   SECPTransferInput,
   TransferableOutput,
@@ -23,7 +22,7 @@ import {
   NFTMintOperation,
   NFTMintOutput
 } from "../../src/apis/avm"
-import { OutputOwners } from "../../src/common";
+import { OutputOwners } from "../../src/common"
 import { Defaults } from "../../src/utils"
   
 const getUTXOIDs = (utxoSet: UTXOSet, txid: string, outputType: number = AVMConstants.SECPXFEROUTPUTID_CODECONE, assetID = "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"): string[] => {

--- a/examples/avm/parseAddress.ts
+++ b/examples/avm/parseAddress.ts
@@ -1,20 +1,20 @@
 import { 
   Avalanche,
   Buffer
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const addressString: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u";
-  const addressBuffer: Buffer = await xchain.parseAddress(addressString);
-  console.log(addressBuffer);
+  const addressString: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+  const addressBuffer: Buffer = xchain.parseAddress(addressString)
+  console.log(addressBuffer)
 }
     
 main()

--- a/examples/avm/refreshBlockchainID.ts
+++ b/examples/avm/refreshBlockchainID.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const success: boolean = await xchain.refreshBlockchainID();
-  console.log(success);
+  const success: boolean = xchain.refreshBlockchainID()
+  console.log(success)
 }
     
 main()

--- a/examples/avm/setAVAXAssetID.ts
+++ b/examples/avm/setAVAXAssetID.ts
@@ -1,21 +1,21 @@
 import { 
   Avalanche,
   Buffer
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const newAssetID: string = "11FtAxv";
-  await xchain.setAVAXAssetID(newAssetID);
-  const assetID: Buffer = await xchain.getAVAXAssetID();
-  console.log(assetID);
+  const newAssetID: string = "11FtAxv"
+  xchain.setAVAXAssetID(newAssetID)
+  const assetID: Buffer = await xchain.getAVAXAssetID()
+  console.log(assetID)
 }
     
 main()

--- a/examples/avm/setBlockchainAlias.ts
+++ b/examples/avm/setBlockchainAlias.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
-  
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
+
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const newAlias: string = "myXChain";
-  await xchain.setBlockchainAlias(newAlias);
+  const newAlias: string = "myXChain"
+  xchain.setBlockchainAlias(newAlias)
 }
     
 main()

--- a/examples/avm/setCreationTxFee.ts
+++ b/examples/avm/setCreationTxFee.ts
@@ -1,21 +1,21 @@
 import { 
   Avalanche,
   BN
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
-  
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
+ 
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const fee: BN = new BN(507);
-  await xchain.setCreationTxFee(fee);
-  const txFee: BN = await xchain.getCreationTxFee();
-  console.log(txFee);
+  const fee: BN = new BN(507)
+  xchain.setCreationTxFee(fee)
+  const txFee: BN = xchain.getCreationTxFee()
+  console.log(txFee)
 }
     
 main()

--- a/examples/avm/setTxFee.ts
+++ b/examples/avm/setTxFee.ts
@@ -1,21 +1,21 @@
 import { 
   Avalanche,
   BN
-} from "../../dist";
-import { AVMAPI } from "../../dist/apis/avm";
-  
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const xchain: AVMAPI = avalanche.XChain();
+} from "../../dist"
+import { AVMAPI } from "../../dist/apis/avm"
+ 
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
   
 const main = async (): Promise<any> => {
-  const fee: BN = new BN(507);
-  await xchain.setTxFee(fee);
-  const txFee: BN = await xchain.getTxFee();
-  console.log(txFee);
+  const fee: BN = new BN(507)
+  xchain.setTxFee(fee)
+  const txFee: BN = xchain.getTxFee()
+  console.log(txFee)
 }
     
 main()

--- a/examples/evm/buildExportTx-xchain-ant.ts
+++ b/examples/evm/buildExportTx-xchain-ant.ts
@@ -1,5 +1,7 @@
 import { 
-  Avalanche, BinTools, BN, Buffer
+  Avalanche, 
+  BinTools, 
+  BN
 } from "../../src"
 import { 
   AVMAPI, 
@@ -30,7 +32,7 @@ const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
-const Web3 = require('web3');
+const Web3 = require('web3')
 const path: string = '/ext/bc/C/rpc'
 const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
@@ -40,7 +42,7 @@ const main = async (): Promise<any> => {
   const fee: BN = cchain.getDefaultTxFee()
   balance = new BN(balance.toString().substring(0, 17))
   const txcount = await web3.eth.getTransactionCount(cHexAddress)
-  const nonce: number = txcount;
+  const nonce: number = txcount
   const locktime: BN = new BN(0)
   const amount: BN = new BN(500)
   const assetID: string = "2DLukZZms6BdwsUea4DtWHReGa6reRw3QWGJfC7z5p7tqHCSxK"

--- a/examples/evm/buildExportTx-xchain-avax.ts
+++ b/examples/evm/buildExportTx-xchain-avax.ts
@@ -20,7 +20,6 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const cchain: EVMAPI = avalanche.CChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: AVMKeyChain = xchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 const cKeychain: EVMKeyChain = cchain.keyChain()
@@ -29,6 +28,7 @@ cKeychain.importKey(privKey)
 const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
 const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
 const Web3 = require('web3');
 const path: string = '/ext/bc/C/rpc'
@@ -36,8 +36,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
           
 const main = async (): Promise<any> => {
-  const avaxAssetIDBuf: Buffer = await xchain.getAVAXAssetID()
-  const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   let balance: BN = await web3.eth.getBalance(cHexAddress)
   const fee: BN = cchain.getDefaultTxFee()
   balance = new BN(balance.toString().substring(0, 17))
@@ -48,7 +46,7 @@ const main = async (): Promise<any> => {
       
   const unsignedTx: UnsignedTx = await cchain.buildExportTx(
     avaxAmount,
-    avaxAssetIDStr,
+    avaxAssetID,
     xChainBlockchainIdStr,
     cHexAddress,
     cAddressStrings[0],

--- a/examples/evm/buildExportTx-xchain-avax.ts
+++ b/examples/evm/buildExportTx-xchain-avax.ts
@@ -1,5 +1,6 @@
 import { 
-  Avalanche, BinTools, BN, Buffer
+  Avalanche, 
+  BN
 } from "../../src"
 import { 
   AVMAPI, 

--- a/examples/evm/buildExportTx-xchain-avax.ts
+++ b/examples/evm/buildExportTx-xchain-avax.ts
@@ -31,7 +31,7 @@ const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
 const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
 const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
-const Web3 = require('web3');
+const Web3 = require('web3')
 const path: string = '/ext/bc/C/rpc'
 const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
@@ -41,7 +41,7 @@ const main = async (): Promise<any> => {
   const fee: BN = cchain.getDefaultTxFee()
   balance = new BN(balance.toString().substring(0, 17))
   const txcount = await web3.eth.getTransactionCount(cHexAddress)
-  const nonce: number = txcount;
+  const nonce: number = txcount
   const locktime: BN = new BN(0)
   const avaxAmount: BN = balance.sub(fee)
       

--- a/examples/evm/exportTx-ant-xchain.ts
+++ b/examples/evm/exportTx-ant-xchain.ts
@@ -45,7 +45,7 @@ const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
 const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const evmInputs: EVMInput[] = []
 let exportedOuts: TransferableOutput[] = []
-const Web3 = require('web3');
+const Web3 = require('web3')
 const path: string = '/ext/bc/C/rpc'
 const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
@@ -63,7 +63,7 @@ const main = async (): Promise<any> => {
   avaxBalance = new BN(avaxBalance.toString().substring(0, 17))
   const fee: BN = cchain.getDefaultTxFee()
   const txcount = await web3.eth.getTransactionCount(cHexAddress)
-  const nonce: number = txcount;
+  const nonce: number = txcount
   const locktime: BN = new BN(0)
     
   let evmInput: EVMInput = new EVMInput(cHexAddress, avaxBalance, avaxAssetID, nonce)
@@ -81,7 +81,7 @@ const main = async (): Promise<any> => {
   secpTransferOutput = new SECPTransferOutput(new BN(antAssetBalance), xAddresses, locktime, threshold)
   transferableOutput = new TransferableOutput(antAssetIDBuf, secpTransferOutput)
   exportedOuts.push(transferableOutput)
-  exportedOuts = exportedOuts.sort(TransferableOutput.comparator());
+  exportedOuts = exportedOuts.sort(TransferableOutput.comparator())
     
   const exportTx: ExportTx = new ExportTx(
     networkID,

--- a/examples/evm/exportTx-ant-xchain.ts
+++ b/examples/evm/exportTx-ant-xchain.ts
@@ -41,6 +41,7 @@ const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const cChainBlockchainIdStr: string = Defaults.network['12345'].C.blockchainID
 const cChainBlockchainIdBuf: Buffer = bintools.cb58Decode(cChainBlockchainIdStr)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const evmInputs: EVMInput[] = []
 let exportedOuts: TransferableOutput[] = []
 const Web3 = require('web3');
@@ -49,7 +50,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
         
 const main = async (): Promise<any> => {
-  const avaxAssetIDBuf: Buffer = await xchain.getAVAXAssetID()
   const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   const antAssetIDStr: string = "verma4Pa9biWKbjDGNsTXU47cYCyDSNGSU1iBkxucfVSFVXdv"
   const antAssetIDBuf: Buffer = bintools.cb58Decode(antAssetIDStr)

--- a/examples/evm/exportTx-ant-xchain.ts
+++ b/examples/evm/exportTx-ant-xchain.ts
@@ -41,7 +41,8 @@ const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const cChainBlockchainIdStr: string = Defaults.network['12345'].C.blockchainID
 const cChainBlockchainIdBuf: Buffer = bintools.cb58Decode(cChainBlockchainIdStr)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
-const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const evmInputs: EVMInput[] = []
 let exportedOuts: TransferableOutput[] = []
 const Web3 = require('web3');
@@ -50,7 +51,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
         
 const main = async (): Promise<any> => {
-  const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   const antAssetIDStr: string = "verma4Pa9biWKbjDGNsTXU47cYCyDSNGSU1iBkxucfVSFVXdv"
   const antAssetIDBuf: Buffer = bintools.cb58Decode(antAssetIDStr)
   const antAssetBalanceResponse: RequestResponseData = await cchain.callMethod("eth_getAssetBalance", [
@@ -66,7 +66,7 @@ const main = async (): Promise<any> => {
   const nonce: number = txcount;
   const locktime: BN = new BN(0)
     
-  let evmInput: EVMInput = new EVMInput(cHexAddress, avaxBalance, avaxAssetIDStr, nonce)
+  let evmInput: EVMInput = new EVMInput(cHexAddress, avaxBalance, avaxAssetID, nonce)
   evmInput.addSignatureIdx(0, cAddresses[0])
   evmInputs.push(evmInput)
     

--- a/examples/evm/exportTx-avax-xchain.ts
+++ b/examples/evm/exportTx-avax-xchain.ts
@@ -39,6 +39,7 @@ const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
 const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const cChainBlockchainIdStr: string = Defaults.network['12345'].C.blockchainID
 const cChainBlockchainIdBuf: Buffer = bintools.cb58Decode(cChainBlockchainIdStr)
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
 const evmInputs: EVMInput[] = []
 const exportedOuts: TransferableOutput[] = []
@@ -48,7 +49,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
         
 const main = async (): Promise<any> => {
-  const avaxAssetIDBuf: Buffer = await xchain.getAVAXAssetID()
   const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   let balance: BN = await web3.eth.getBalance(cHexAddress)
   balance = new BN(balance.toString().substring(0, 17))

--- a/examples/evm/exportTx-avax-xchain.ts
+++ b/examples/evm/exportTx-avax-xchain.ts
@@ -39,7 +39,8 @@ const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
 const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const cChainBlockchainIdStr: string = Defaults.network['12345'].C.blockchainID
 const cChainBlockchainIdBuf: Buffer = bintools.cb58Decode(cChainBlockchainIdStr)
-const avaxAssetIDBuf: Buffer = bintools.cb58Decode(Defaults.network['12345'].X.avaxAssetID)
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
 const evmInputs: EVMInput[] = []
 const exportedOuts: TransferableOutput[] = []
@@ -49,7 +50,6 @@ const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
         
 const main = async (): Promise<any> => {
-  const avaxAssetIDStr: string = bintools.cb58Encode(avaxAssetIDBuf)
   let balance: BN = await web3.eth.getBalance(cHexAddress)
   balance = new BN(balance.toString().substring(0, 17))
   const fee: BN = cchain.getDefaultTxFee()
@@ -57,7 +57,7 @@ const main = async (): Promise<any> => {
   const nonce: number = txcount;
   const locktime: BN = new BN(0)
     
-  const evmInput: EVMInput = new EVMInput(cHexAddress, balance, avaxAssetIDStr, nonce)
+  const evmInput: EVMInput = new EVMInput(cHexAddress, balance, avaxAssetID, nonce)
   evmInput.addSignatureIdx(0, cAddresses[0])
   evmInputs.push(evmInput)
     

--- a/examples/evm/exportTx-avax-xchain.ts
+++ b/examples/evm/exportTx-avax-xchain.ts
@@ -44,7 +44,7 @@ const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const cHexAddress: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
 const evmInputs: EVMInput[] = []
 const exportedOuts: TransferableOutput[] = []
-const Web3 = require('web3');
+const Web3 = require('web3')
 const path: string = '/ext/bc/C/rpc'
 const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
 const threshold: number = 1
@@ -54,7 +54,7 @@ const main = async (): Promise<any> => {
   balance = new BN(balance.toString().substring(0, 17))
   const fee: BN = cchain.getDefaultTxFee()
   const txcount = await web3.eth.getTransactionCount(cHexAddress)
-  const nonce: number = txcount;
+  const nonce: number = txcount
   const locktime: BN = new BN(0)
     
   const evmInput: EVMInput = new EVMInput(cHexAddress, balance, avaxAssetID, nonce)

--- a/examples/evm/importTx-xchain.ts
+++ b/examples/evm/importTx-xchain.ts
@@ -38,6 +38,7 @@ const xChainBlockchainIdStr: string = Defaults.network['12345'].X.blockchainID
 const xChainBlockchainIdBuf: Buffer = bintools.cb58Decode(xChainBlockchainIdStr)
 const importedIns: TransferableInput[] = []
 const evmOutputs: EVMOutput[] = []
+const fee: BN = cchain.getDefaultTxFee()
           
 const main = async (): Promise<any> => {
   const u: any = await cchain.getUTXOs(cAddressStrings[0], "X")
@@ -54,7 +55,7 @@ const main = async (): Promise<any> => {
     const xferin: TransferableInput = new TransferableInput(txid, outputidx, assetID, input)
     importedIns.push(xferin)
   
-    const evmOutput: EVMOutput = new EVMOutput(cHexAddress, amt, assetID)
+    const evmOutput: EVMOutput = new EVMOutput(cHexAddress, amt.sub(fee), assetID)
     evmOutputs.push(evmOutput)
   })
       

--- a/examples/health/getLiveness.ts
+++ b/examples/health/getLiveness.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../src";
-import { HealthAPI } from "../../src/apis/health";
+} from "../../src"
+import { HealthAPI } from "../../src/apis/health"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const health: HealthAPI = avalanche.Health();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const health: HealthAPI = avalanche.Health()
   
 const main = async (): Promise<any> => {
-  const getLivenessResponse: object= await health.getLiveness();
-  console.log(getLivenessResponse);
+  const getLivenessResponse: object= await health.getLiveness()
+  console.log(getLivenessResponse)
 }
     
 main()

--- a/examples/index/getContainerByID.ts
+++ b/examples/index/getContainerByID.ts
@@ -1,24 +1,24 @@
 import { 
   Avalanche
-} from "../../src";
-import { IndexAPI } from "../../src/apis/index";
+} from "../../src"
+import { IndexAPI } from "../../src/apis/index"
 import { 
   GetContainerByIDResponse
-} from '../../src/common/interfaces';
+} from '../../src/common/interfaces'
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const index: IndexAPI = avalanche.Index();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const index: IndexAPI = avalanche.Index()
   
 const main = async (): Promise<any> => {
-  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT";
-  const encoding: string = 'cb58';
+  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT"
+  const encoding: string = 'cb58'
   const baseurl: string = "/ext/index/C/block"
-  const containerByIndex: GetContainerByIDResponse = await index.getContainerByID(containerID, encoding, baseurl);
-  console.log(containerByIndex);
+  const containerByIndex: GetContainerByIDResponse = await index.getContainerByID(containerID, encoding, baseurl)
+  console.log(containerByIndex)
 }
     
 main()

--- a/examples/index/getContainerByIndex.ts
+++ b/examples/index/getContainerByIndex.ts
@@ -1,24 +1,24 @@
 import { 
   Avalanche
-} from "../../src";
-import { IndexAPI } from "../../src/apis/index";
+} from "../../src"
+import { IndexAPI } from "../../src/apis/index"
 import { 
   GetContainerByIndexResponse
-} from '../../src/common/interfaces';
+} from '../../src/common/interfaces'
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const index: IndexAPI = avalanche.Index();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const index: IndexAPI = avalanche.Index()
   
 const main = async (): Promise<any> => {
-  const idx: string = "0";
-  const encoding: string = 'cb58';
+  const idx: string = "0"
+  const encoding: string = 'cb58'
   const baseurl: string = "/ext/index/C/block"
-  const containerByIndex: GetContainerByIndexResponse = await index.getContainerByIndex(idx, encoding, baseurl);
-  console.log(containerByIndex);
+  const containerByIndex: GetContainerByIndexResponse = await index.getContainerByIndex(idx, encoding, baseurl)
+  console.log(containerByIndex)
 }
     
 main()

--- a/examples/index/getContainerRange.ts
+++ b/examples/index/getContainerRange.ts
@@ -1,25 +1,25 @@
 import { 
   Avalanche
-} from "../../src";
-import { IndexAPI } from "../../src/apis/index";
+} from "../../src"
+import { IndexAPI } from "../../src/apis/index"
 import { 
   GetContainerRangeResponse
-} from '../../src/common/interfaces';
+} from '../../src/common/interfaces'
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const index: IndexAPI = avalanche.Index();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const index: IndexAPI = avalanche.Index()
   
 const main = async (): Promise<any> => {
-  const startIndex: number = 0;
-  const numToFetch: number = 100;
-  const encoding: string = "hex";
+  const startIndex: number = 0
+  const numToFetch: number = 100
+  const encoding: string = "hex"
   const baseurl: string = "/ext/index/C/block"
-  const containerRange: GetContainerRangeResponse[] = await index.getContainerRange(startIndex, numToFetch, encoding, baseurl);
-  console.log(containerRange);
+  const containerRange: GetContainerRangeResponse[] = await index.getContainerRange(startIndex, numToFetch, encoding, baseurl)
+  console.log(containerRange)
 }
     
 main()

--- a/examples/index/getIndex.ts
+++ b/examples/index/getIndex.ts
@@ -1,21 +1,21 @@
 import { 
   Avalanche
-} from "../../src";
-import { IndexAPI } from "../../src/apis/index";
+} from "../../src"
+import { IndexAPI } from "../../src/apis/index"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const index: IndexAPI = avalanche.Index();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const index: IndexAPI = avalanche.Index()
   
 const main = async (): Promise<any> => {
-  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT";
-  const encoding: string = "hex";
+  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT"
+  const encoding: string = "hex"
   const baseurl: string = "/ext/index/C/block"
-  const containerRange: string = await index.getIndex(containerID, encoding, baseurl);
-  console.log(containerRange);
+  const containerRange: string = await index.getIndex(containerID, encoding, baseurl)
+  console.log(containerRange)
 }
     
 main()

--- a/examples/index/getLastAccepted.ts
+++ b/examples/index/getLastAccepted.ts
@@ -1,23 +1,23 @@
 import { 
   Avalanche
-} from "../../src";
-import { IndexAPI } from "../../src/apis/index";
+} from "../../src"
+import { IndexAPI } from "../../src/apis/index"
 import { 
   GetLastAcceptedResponse,
-} from '../../src/common/interfaces';
+} from '../../src/common/interfaces'
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const index: IndexAPI = avalanche.Index();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const index: IndexAPI = avalanche.Index()
   
 const main = async (): Promise<any> => {
-  const encoding: string = 'cb58';
+  const encoding: string = 'cb58'
   const baseurl: string = "/ext/index/X/tx"  
-  const lastAccepted: GetLastAcceptedResponse = await index.getLastAccepted(encoding, baseurl);
-  console.log(lastAccepted);
+  const lastAccepted: GetLastAcceptedResponse = await index.getLastAccepted(encoding, baseurl)
+  console.log(lastAccepted)
 }
     
 main()

--- a/examples/index/isAccepted.ts
+++ b/examples/index/isAccepted.ts
@@ -1,21 +1,21 @@
 import { 
   Avalanche
-} from "../../src";
-import { IndexAPI } from "../../src/apis/index";
+} from "../../src"
+import { IndexAPI } from "../../src/apis/index"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const index: IndexAPI = avalanche.Index();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const index: IndexAPI = avalanche.Index()
   
 const main = async (): Promise<any> => {
-  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT";
-  const encoding: string = "hex";
+  const containerID: string = "2ceDnmxh59AsXqTG95vf3dr2a7ohXprNn9mvWgQJ39uHryBecT"
+  const encoding: string = "hex"
   const baseurl: string = "/ext/index/C/block"
-  const containerRange: boolean = await index.isAccepted(containerID, encoding, baseurl);
-  console.log(containerRange);
+  const containerRange: boolean = await index.isAccepted(containerID, encoding, baseurl)
+  console.log(containerRange)
 }
     
 main()

--- a/examples/info/getBlockchainID.ts
+++ b/examples/info/getBlockchainID.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const alias: string = "X";
-  const blockchainID : string = await info.getBlockchainID(alias);
-  console.log(blockchainID);
+  const alias: string = "X"
+  const blockchainID : string = await info.getBlockchainID(alias)
+  console.log(blockchainID)
 }
     
 main()

--- a/examples/info/getNetworkID.ts
+++ b/examples/info/getNetworkID.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const networkID : number = await info.getNetworkID();
-  console.log(networkID);
+  const networkID : number = await info.getNetworkID()
+  console.log(networkID)
 }
     
 main()

--- a/examples/info/getNetworkName.ts
+++ b/examples/info/getNetworkName.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const networkName : string = await info.getNetworkName();
-  console.log(networkName);
+  const networkName : string = await info.getNetworkName()
+  console.log(networkName)
 }
     
 main()

--- a/examples/info/getNodeID.ts
+++ b/examples/info/getNodeID.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const nodeID: string = await info.getNodeID();
-  console.log(nodeID);
+  const nodeID: string = await info.getNodeID()
+  console.log(nodeID)
 }
     
 main()

--- a/examples/info/getNodeVersion.ts
+++ b/examples/info/getNodeVersion.ts
@@ -1,18 +1,18 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const nodeVersion: string = await info.getNodeVersion();
-  console.log(nodeVersion);
+  const nodeVersion: string = await info.getNodeVersion()
+  console.log(nodeVersion)
 }
     
 main()

--- a/examples/info/getTxFee.ts
+++ b/examples/info/getTxFee.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
-import { iGetTxFeeResponse } from "../../dist/apis/info/interfaces";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
+import { iGetTxFeeResponse } from "../../dist/apis/info/interfaces"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const iGetTxFeeResponse: iGetTxFeeResponse = await info.getTxFee();
-  console.log(iGetTxFeeResponse);
+  const iGetTxFeeResponse: iGetTxFeeResponse = await info.getTxFee()
+  console.log(iGetTxFeeResponse)
 }
     
 main()

--- a/examples/info/isBootstrapped.ts
+++ b/examples/info/isBootstrapped.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const chain: string = "X";
-  const bootstrapped: boolean = await info.isBootstrapped(chain);
-  console.log(bootstrapped);
+  const chain: string = "X"
+  const bootstrapped: boolean = await info.isBootstrapped(chain)
+  console.log(bootstrapped)
 }
     
 main()

--- a/examples/info/peers.ts
+++ b/examples/info/peers.ts
@@ -1,19 +1,19 @@
 import { 
   Avalanche
-} from "../../dist";
-import { InfoAPI } from "../../dist/apis/info";
-import { PeersResponse } from "../../dist/common/interfaces";
+} from "../../dist"
+import { InfoAPI } from "../../dist/apis/info"
+import { PeersResponse } from "../../dist/common/interfaces"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const info: InfoAPI = avalanche.Info();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const info: InfoAPI = avalanche.Info()
   
 const main = async (): Promise<any> => {
-  const peers: PeersResponse = await info.peers([]);
-  console.log(peers);
+  const peers: PeersResponse = await info.peers([])
+  console.log(peers)
 }
     
 main()

--- a/examples/keystore/createUser.ts
+++ b/examples/keystore/createUser.ts
@@ -1,18 +1,18 @@
-import { Avalanche } from "../../dist";
-import { KeystoreAPI } from "../../dist/apis/keystore";
+import { Avalanche } from "../../dist"
+import { KeystoreAPI } from "../../dist/apis/keystore"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const keystore: KeystoreAPI = avalanche.NodeKeys();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const keystore: KeystoreAPI = avalanche.NodeKeys()
   
 const main = async (): Promise<any> => {
-  const username: string = "username";
+  const username: string = "username"
   const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const successful: boolean = await keystore.createUser(username, password);
-  console.log(successful);
+  const successful: boolean = await keystore.createUser(username, password)
+  console.log(successful)
 }
     
 main()

--- a/examples/keystore/deleteUser.ts
+++ b/examples/keystore/deleteUser.ts
@@ -1,18 +1,18 @@
-import { Avalanche } from "../../dist";
-import { KeystoreAPI } from "../../dist/apis/keystore";
+import { Avalanche } from "../../dist"
+import { KeystoreAPI } from "../../dist/apis/keystore"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const keystore: KeystoreAPI = avalanche.NodeKeys();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const keystore: KeystoreAPI = avalanche.NodeKeys()
   
 const main = async (): Promise<any> => {
-  const username: string = "username";
+  const username: string = "username"
   const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const successful: boolean = await keystore.deleteUser(username, password);
-  console.log(successful);
+  const successful: boolean = await keystore.deleteUser(username, password)
+  console.log(successful)
 }
     
 main()

--- a/examples/keystore/exportUser.ts
+++ b/examples/keystore/exportUser.ts
@@ -1,18 +1,18 @@
-import { Avalanche } from "../../dist";
-import { KeystoreAPI } from "../../dist/apis/keystore";
+import { Avalanche } from "../../dist"
+import { KeystoreAPI } from "../../dist/apis/keystore"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const keystore: KeystoreAPI = avalanche.NodeKeys();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const keystore: KeystoreAPI = avalanche.NodeKeys()
   
 const main = async (): Promise<any> => {
-  const username: string = "username";
+  const username: string = "username"
   const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const user: string = await keystore.exportUser(username, password);
-  console.log(user);
+  const user: string = await keystore.exportUser(username, password)
+  console.log(user)
 }
     
 main()

--- a/examples/keystore/importUser.ts
+++ b/examples/keystore/importUser.ts
@@ -1,19 +1,19 @@
-import { Avalanche } from "../../dist";
-import { KeystoreAPI } from "../../dist/apis/keystore";
+import { Avalanche } from "../../dist"
+import { KeystoreAPI } from "../../dist/apis/keystore"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const keystore: KeystoreAPI = avalanche.NodeKeys();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const keystore: KeystoreAPI = avalanche.NodeKeys()
   
 const main = async (): Promise<any> => {
-  const username: string = "username";
+  const username: string = "username"
   const password: string = "Vz48jjHLTCcAepH95nT4B"
   const user: string = "115mXVPYAAB6434yBs9Frw84j6HVbtxJS5RywzskeAHyjpXoZ6AnPCwGfUhduG3vuDnSVxcSKxVXmGN"
-  const successful: boolean = await keystore.importUser(username, user, password);
-  console.log(successful);
+  const successful: boolean = await keystore.importUser(username, user, password)
+  console.log(successful)
 }
     
 main()

--- a/examples/keystore/listUsers.ts
+++ b/examples/keystore/listUsers.ts
@@ -1,16 +1,16 @@
-import { Avalanche } from "../../dist";
-import { KeystoreAPI } from "../../dist/apis/keystore";
+import { Avalanche } from "../../dist"
+import { KeystoreAPI } from "../../dist/apis/keystore"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const keystore: KeystoreAPI = avalanche.NodeKeys();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const keystore: KeystoreAPI = avalanche.NodeKeys()
   
 const main = async (): Promise<any> => {
-  const users: string[] = await keystore.listUsers();
-  console.log(users);
+  const users: string[] = await keystore.listUsers()
+  console.log(users)
 }
     
 main()

--- a/examples/metrics/getMetrics.ts
+++ b/examples/metrics/getMetrics.ts
@@ -1,16 +1,16 @@
-import { Avalanche } from "../../dist";
-import { MetricsAPI } from "../../dist/apis/metrics";
+import { Avalanche } from "../../dist"
+import { MetricsAPI } from "../../dist/apis/metrics"
   
-const ip: string = 'localhost';
-const port: number = 9650;
-const protocol: string = 'http';
-const networkID: number = 12345;
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID);
-const metrics: MetricsAPI = avalanche.Metrics();
+const ip: string = 'localhost'
+const port: number = 9650
+const protocol: string = 'http'
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const metrics: MetricsAPI = avalanche.Metrics()
   
 const main = async (): Promise<any> => {
-  const m: string = await metrics.getMetrics();
-  console.log(m);
+  const m: string = await metrics.getMetrics()
+  console.log(m)
 }
     
 main()

--- a/examples/platformvm/addDelegatorTx.ts
+++ b/examples/platformvm/addDelegatorTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
@@ -20,7 +20,7 @@ import {
   SECPOwnerOutput,
   ParseableOutput
 } from "../../src/apis/platformvm"
-import { Output } from "../../src/common";
+import { Output } from "../../src/common"
 import { 
   Defaults, 
   NodeIDStringToBuffer, 

--- a/examples/platformvm/addValidatorTx.ts
+++ b/examples/platformvm/addValidatorTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
@@ -20,7 +20,7 @@ import {
   SECPOwnerOutput,
   ParseableOutput
 } from "../../src/apis/platformvm"
-import { Output } from "../../src/common";
+import { Output } from "../../src/common"
 import { Defaults, NodeIDStringToBuffer, UnixNow } from "../../src/utils"
       
 const ip: string = "localhost"

--- a/examples/platformvm/buildAddDelegatorTx.ts
+++ b/examples/platformvm/buildAddDelegatorTx.ts
@@ -1,15 +1,14 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
   UTXOSet,
   UnsignedTx,
-  Tx,
+  Tx
 } from "../../src/apis/platformvm"
 import { UnixNow } from "../../src/utils"
       
@@ -19,7 +18,6 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const pKeychain: KeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 pKeychain.importKey(privKey)

--- a/examples/platformvm/buildAddValidatorTx.ts
+++ b/examples/platformvm/buildAddValidatorTx.ts
@@ -1,15 +1,14 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
   UTXOSet,
   UnsignedTx,
-  Tx,
+  Tx
 } from "../../src/apis/platformvm"
 import { UnixNow } from "../../src/utils"
       
@@ -19,7 +18,6 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const pKeychain: KeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 pKeychain.importKey(privKey)

--- a/examples/platformvm/buildCreateSubnetTx.ts
+++ b/examples/platformvm/buildCreateSubnetTx.ts
@@ -1,17 +1,16 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
   UTXOSet,
   UnsignedTx,
-  Tx,
+  Tx
 } from "../../src/apis/platformvm"
-import { UnixNow } from "../../src/utils";
+import { UnixNow } from "../../src/utils"
       
 const ip: string = "localhost"
 const port: number = 9650
@@ -19,7 +18,6 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const pKeychain: KeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 pKeychain.importKey(privKey)

--- a/examples/platformvm/buildExportTx.ts
+++ b/examples/platformvm/buildExportTx.ts
@@ -1,19 +1,18 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import { 
   AVMAPI,
   KeyChain as AVMKeyChain
-} from "../../src/apis/avm";
+} from "../../src/apis/avm"
 import {
   PlatformVMAPI, 
   KeyChain,
   UTXOSet,
   UnsignedTx,
-  Tx,
+  Tx
 } from "../../src/apis/platformvm"
 import { Defaults, UnixNow } from "../../src/utils"
       
@@ -24,7 +23,6 @@ const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const xKeychain: AVMKeyChain = xchain.keyChain()
 const pKeychain: KeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"

--- a/examples/platformvm/buildImportTx.ts
+++ b/examples/platformvm/buildImportTx.ts
@@ -1,15 +1,14 @@
 import { 
   Avalanche,
-  BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
   UTXOSet,
   UnsignedTx,
-  Tx,
+  Tx
 } from "../../src/apis/platformvm"
 import { Defaults, UnixNow } from "../../src/utils"
       
@@ -19,7 +18,6 @@ const protocol: string = "http"
 const networkID: number = 12345
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const pKeychain: KeyChain = pchain.keyChain()
 const privKey: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 pKeychain.importKey(privKey)

--- a/examples/platformvm/createSubnetTx.ts
+++ b/examples/platformvm/createSubnetTx.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,
@@ -19,7 +19,7 @@ import {
   Tx,
   SECPOwnerOutput,
 } from "../../src/apis/platformvm"
-import { Output } from "../../src/common";
+import { Output } from "../../src/common"
 import { Defaults } from "../../src/utils"
       
 const ip: string = "localhost"

--- a/examples/platformvm/exportTx-xchain.ts
+++ b/examples/platformvm/exportTx-xchain.ts
@@ -3,11 +3,11 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import { 
   AVMAPI,
   KeyChain as AVMKeyChain 
-} from "../../src/apis/avm";
+} from "../../src/apis/avm"
 import {
   PlatformVMAPI, 
   KeyChain,
@@ -22,7 +22,7 @@ import {
   Tx,
   ExportTx
 } from "../../src/apis/platformvm"
-import { Output } from "../../src/common";
+import { Output } from "../../src/common"
 import { Defaults } from "../../src/utils"
       
 const ip: string = "localhost"

--- a/examples/platformvm/importTx-xchain.ts
+++ b/examples/platformvm/importTx-xchain.ts
@@ -3,7 +3,7 @@ import {
   BinTools,
   BN,
   Buffer
-} from "../../src";
+} from "../../src"
 import {
   PlatformVMAPI, 
   KeyChain,

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   ],
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json'
     }
   },
   moduleNameMapper: {

--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -536,7 +536,7 @@ export class EVMAPI extends JRPCAPI {
     const builtUnsignedTx: UnsignedTx = utxoset.buildImportTx(
       networkID,
       bintools.cb58Decode(this.blockchainID), 
-      [toAddress],
+      toAddress,
       from,
       atomics,
       sourceChain,

--- a/src/apis/evm/api.ts
+++ b/src/apis/evm/api.ts
@@ -524,7 +524,9 @@ export class EVMAPI extends JRPCAPI {
     }
     const utxoResponse: UTXOResponse = await this.getUTXOs(ownerAddresses, srcChain, 0, undefined);
     const atomicUTXOs: UTXOSet = utxoResponse.utxos;
-    const avaxAssetID: Buffer = await this.getAVAXAssetID();
+    const networkID: number = this.core.getNetworkID();
+    const avaxAssetID: string = Defaults.network[networkID].X.avaxAssetID;
+    const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID);
     const atomics: UTXO[] = atomicUTXOs.getAllUTXOs();
 
     if(atomics.length === 0){
@@ -532,14 +534,14 @@ export class EVMAPI extends JRPCAPI {
     }
 
     const builtUnsignedTx: UnsignedTx = utxoset.buildImportTx(
-      this.core.getNetworkID(),
+      networkID,
       bintools.cb58Decode(this.blockchainID), 
       [toAddress],
       from,
       atomics,
       sourceChain,
       this.getTxFee(),
-      avaxAssetID
+      avaxAssetIDBuf
     );
 
     return builtUnsignedTx;

--- a/src/apis/evm/importtx.ts
+++ b/src/apis/evm/importtx.ts
@@ -209,7 +209,7 @@ export class ImportTx extends EVMBaseTx {
     this.sourceChain = sourceChainid;
     let inputsPassed: boolean = false;
     let outputsPassed: boolean = false;
-    if(typeof importIns !== 'undefined' && Array.isArray(importIns)) {
+    if(typeof importIns !== 'undefined' && Array.isArray(importIns) && importIns.length > 0) {
       importIns.forEach((importIn: TransferableInput) => {
         if (!(importIn instanceof TransferableInput)) {
           throw new TransferableInputError("Error - ImportTx.constructor: invalid TransferableInput in array parameter 'importIns'");
@@ -218,7 +218,7 @@ export class ImportTx extends EVMBaseTx {
       inputsPassed = true;
       this.importIns = importIns;
     }
-    if(typeof outs !== 'undefined' && Array.isArray(outs)) {
+    if(typeof outs !== 'undefined' && Array.isArray(outs) && outs.length > 0) {
       outs.forEach((out: EVMOutput) => {
         if (!(out instanceof EVMOutput)) {
           throw new EVMOutputError("Error - ImportTx.constructor: invalid EVMOutput in array parameter 'outs'");

--- a/src/apis/evm/importtx.ts
+++ b/src/apis/evm/importtx.ts
@@ -236,7 +236,7 @@ export class ImportTx extends EVMBaseTx {
   }
 
   private validateOuts(): void {
-      // This Map enforce uniqueness of pair(address, assetId) for each EVMOutput
+      // This Map enforces uniqueness of pair(address, assetId) for each EVMOutput.
       // For each imported assetID, each ETH-style C-Chain address can 
       // have exactly 1 EVMOutput.
       // Map(2) {

--- a/src/apis/evm/index.ts
+++ b/src/apis/evm/index.ts
@@ -1,5 +1,5 @@
 export * from './api';
-// export * from './basetx';
+export * from './basetx';
 export * from './constants';
 export * from './credentials';
 export * from './inputs';

--- a/src/apis/evm/utxos.ts
+++ b/src/apis/evm/utxos.ts
@@ -292,19 +292,17 @@ import { UTXOError, AddressError, InsufficientFundsError, FeeAssetError } from '
      }
  
      let feepaid: BN = new BN(0);
-     const feeAssetStr: string = feeAssetID.toString("hex");
      atomics.forEach((atomic: UTXO) => {
        const assetID: Buffer = atomic.getAssetID(); 
        const output: AmountOutput = atomic.getOutput() as AmountOutput;
        const amt: BN = output.getAmount().clone();
  
        let infeeamount: BN = amt.clone();
-       const assetStr: string = assetID.toString("hex");
        if(
          typeof feeAssetID !== "undefined" && 
          fee.gt(zero) && 
          feepaid.lt(fee) && 
-         assetStr === feeAssetStr
+         (Buffer.compare(feeAssetID, assetID) === 0)
        ) 
        {
          feepaid = feepaid.add(infeeamount);
@@ -339,7 +337,7 @@ import { UTXOError, AddressError, InsufficientFundsError, FeeAssetError } from '
        if(infeeamount.gt(zero)) {
          const evmOutput: EVMOutput = new EVMOutput(
            toAddresses[0],
-           amt,
+           (Buffer.compare(feeAssetID, assetID) === 0 ? infeeamount : amt),
            assetID
          );
          outs.push(evmOutput);

--- a/src/apis/evm/utxos.ts
+++ b/src/apis/evm/utxos.ts
@@ -292,7 +292,7 @@ import { UTXOError, AddressError, InsufficientFundsError, FeeAssetError } from '
      }
  
      let feepaid: BN = new BN(0);
-     const map: Map<string, {amount: string}> = new Map();
+     const map: Map<string, string> = new Map();
      atomics.forEach((atomic: UTXO) => {
        const assetIDBuf: Buffer = atomic.getAssetID(); 
        const assetID: string = bintools.cb58Encode(atomic.getAssetID()); 
@@ -336,22 +336,16 @@ import { UTXOError, AddressError, InsufficientFundsError, FeeAssetError } from '
        ins = ins.sort(TransferableInput.comparator());
 
        if(map.has(assetID)) {
-         let a: BN = new BN(map.get(assetID).amount);
-         map.set(assetID, {
-           amount: a.add(infeeamount).toString()
-         });
-       } else {
-         map.set(assetID, {
-           amount: infeeamount.toString()
-         });
+         infeeamount = infeeamount.add(new BN(map.get(assetID)));
        }
+       map.set(assetID, infeeamount.toString());
      });
 
-     for (let [assetID, amount] of map) {
+     for(let [assetID, amount] of map) {
        // Create single EVMOutput for each assetID
         const evmOutput: EVMOutput = new EVMOutput(
           toAddress,
-          new BN(amount.amount),
+          new BN(amount),
           bintools.cb58Decode(assetID)
         );
         outs.push(evmOutput);

--- a/src/apis/evm/utxos.ts
+++ b/src/apis/evm/utxos.ts
@@ -349,7 +349,6 @@ import { UTXOError, AddressError, InsufficientFundsError, FeeAssetError } from '
 
      for (let [assetID, amount] of map) {
        // Create single EVMOutput for each assetID
-       console.log(assetID, amount.toString());
         const evmOutput: EVMOutput = new EVMOutput(
           toAddress,
           new BN(amount.amount),

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -90,6 +90,7 @@ export const AVAXGWEI:BN = NANOAVAX.clone();
 
 export const AVAXSTAKECAP:BN = ONEAVAX.mul(new BN(3000000));
 
+// Start Manhattan 
 const n0X:object = {
   blockchainID: '2vrXWHgGxh5n3YsLHMV16YVVJTpT4z45Fmb4y3bL6si8kLCyg9',
   alias: XChainAlias,
@@ -123,11 +124,13 @@ const n0C:object = {
   gasPrice: GWEI.mul(new BN(470)), //equivalent to gas price
   chainID: 43111
 };
+// End Manhattan 
 
-// TODO: UPDATE FOR MAINNET
-
+// Start mainnet
+let avaxAssetID: string = 'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z';
 const n1X:object = {
   blockchainID: '2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM',
+  avaxAssetID: avaxAssetID,
   alias: XChainAlias,
   vm: XChainVMName,
   txFee: MILLIAVAX,
@@ -136,6 +139,7 @@ const n1X:object = {
 
 const n1P:object = {
   blockchainID: PlatformChainID,
+  avaxAssetID: avaxAssetID,
   alias: PChainAlias,
   vm: PChainVMName,
   txFee: MILLIAVAX,
@@ -159,9 +163,9 @@ const n1C:object = {
   gasPrice: GWEI.mul(new BN(225)), 
   chainID: 43114
 };
+// End Mainnet
 
-// END TODO
-
+// Start Cascade
 const n2X:object = {
   blockchainID: '4ktRjsAKxgMr2aEzv9SWmrU7Xk5FniHUrVCX4P1TZSfTLZWFM',
   alias: XChainAlias,
@@ -193,7 +197,9 @@ const n2C:object = {
   vm: CChainVMName,
   gasPrice: 0
 };
+// End Cascade
 
+// Start Denali
 const n3X:object = {
   blockchainID: 'rrEWX7gc7D9mwcdrdBxBTdqh1a7WDVsMuadhTZgyXfFcRz45L',
   alias: XChainAlias,
@@ -225,7 +231,9 @@ const n3C:object = {
   vm: CChainVMName,
   gasPrice: 0
 };
+// End Denali
 
+// Start Everest
 const n4X:object = {
   blockchainID: 'jnUjZSRt16TcRnZzmh5aMhavwVHz3zBrSN8GfFMTQkzUnoBxC',
   alias: XChainAlias,
@@ -258,10 +266,13 @@ const n4C:object = {
   gasPrice: GWEI.mul(new BN(470)),
   chainID: 43110
 };
+// End Everest
 
-// TODO: UPDATE FOR FUJI
+// Start Fuji
+avaxAssetID = 'U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK';
 const n5X:object = {
   blockchainID: '2JVSBoinj9C2J33VntvzYtVJNZdN2NKiwwKjcumHUWEb5DbBrm',
+  avaxAssetID: avaxAssetID,
   alias: XChainAlias,
   vm: XChainVMName,
   txFee: MILLIAVAX,
@@ -270,6 +281,7 @@ const n5X:object = {
 
 const n5P:object = {
   blockchainID: PlatformChainID,
+  avaxAssetID: avaxAssetID,
   alias: PChainAlias,
   vm: PChainVMName,
   txFee: MILLIAVAX,
@@ -293,16 +305,20 @@ const n5C:object = {
   gasPrice: GWEI.mul(new BN(225)), 
   chainID: 43113
 };
+// End Fuji
 
-// END TODO
-
+// Start local network
+avaxAssetID = '2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe';
 const n12345X:any = { ...n5X };
 n12345X.blockchainID = '2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed';
+n12345X.avaxAssetID = avaxAssetID;
 const n12345P:any = { ...n5P };
 n12345P.blockchainID = PlatformChainID;
 const n12345C:any = { ...n5C };
-n12345C.blockchainID = '2XFHbWN57HrjHW1JqhP9wzj92eYHpiH7EGLnY9mNfWn9w9CvWR';
+n12345C.blockchainID = '2CA6j5zYzasynPsFeNoqWkmTCt3VScMvXUZHbfDJ8k3oGzAPtU';
+n12345C.avaxAssetID = avaxAssetID;
 n12345C.chainID = 43112;
+// End local network
 
 export class Defaults {
   static network = {
@@ -315,7 +331,7 @@ export class Defaults {
       C: n0C,
       '2fFZQibQXcd6LTE4rpBPBAkLVXFE91Kit8pgxaBG1mRnh5xqbb': n0C,
     }, 
-    1: { // update before mainnet
+    1: {
       hrp: NetworkIDToHRP[1],
       X: n1X,
       '2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM': n1X,
@@ -367,7 +383,7 @@ export class Defaults {
       P: n12345P,
       '11111111111111111111111111111111LpoYY': n12345P,
       C: n12345C,
-      '2XFHbWN57HrjHW1JqhP9wzj92eYHpiH7EGLnY9mNfWn9w9CvWR': n12345C,
+      '2CA6j5zYzasynPsFeNoqWkmTCt3VScMvXUZHbfDJ8k3oGzAPtU': n12345C,
     },
   };
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -37,6 +37,7 @@ const TYPE_ID_ERROR_CODE:string = "1035";
 const TYPE_NAME_ERROR_CODE:string = "1035";
 const UNKNOWN_TYPE_ERROR_CODE:string = "1036";
 const BECH32_ERROR_CODE:string = "1037";
+const EVM_FEE_ERROR_CODE:string = "1038";
 
 class AvalancheError extends Error {
   errorCode: string;
@@ -322,5 +323,13 @@ export class Bech32Error extends AvalancheError {
   constructor(m:string) {
     super(m, BECH32_ERROR_CODE);
     Object.setPrototypeOf(this, Bech32Error.prototype);
+  }
+}
+
+
+export class EVMFeeError extends AvalancheError {
+  constructor(m:string) {
+    super(m, EVM_FEE_ERROR_CODE);
+    Object.setPrototypeOf(this, EVMFeeError.prototype);
   }
 }

--- a/tests/apis/evm/tx.test.ts
+++ b/tests/apis/evm/tx.test.ts
@@ -1,0 +1,134 @@
+import { 
+  ImportTx, 
+  SECPTransferInput, 
+  TransferableInput 
+} from 'src/apis/evm';
+import { Defaults, MILLIAVAX } from 'src/utils/constants';
+import { ONEAVAX } from '../../../src/utils/constants';
+import { EVMOutput } from 'src/apis/evm';
+import BN from "bn.js";
+import { 
+  BinTools,
+  Buffer 
+} from 'src';
+const networkID: number = 12345;
+const cHexAddress1: string = "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC";
+const bintools: BinTools = BinTools.getInstance()
+const cHexAddress2: string = "0xecC3B2968B277b837a81A7181e0b94EB1Ca54EdE";
+const antAssetID: string = "F4MyJcUvq3Rxbqgd4Zs8sUpvwLHApyrp4yxJXe2bAV86Vvp38";
+const avaxAssetID: string = Defaults.network['12345'].X.avaxAssetID;
+const txID: string = "QVb7DtKjcwVYLFWHgnGSdzQtQSc29KeRBYFNCBnbFu6dFqX7z";
+const blockchainID: string = Defaults.network['12345'].C.blockchainID;
+const sourcechainID: string = Defaults.network['12345'].X.blockchainID;
+let evmOutputs: EVMOutput[];
+let importedIns: TransferableInput[];
+const fee: BN = Defaults.network['12345'].C.txFee;
+
+beforeEach((): void => {
+  evmOutputs = [];
+  importedIns = [];
+});
+
+describe('EVM Transactions', () => {
+  describe('ImportTx', () => {
+    test("Multiple AVAX EVMOutput fail", (): void => {
+      // Creating 2 outputs with the same address and AVAX assetID is invalid
+      let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, avaxAssetID);
+      evmOutputs.push(evmOutput);
+      evmOutput = new EVMOutput(cHexAddress1, ONEAVAX, avaxAssetID);
+      evmOutputs.push(evmOutput);
+
+      expect((): void => {
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), [], evmOutputs);
+      }).toThrow("Error - ImportTx: duplicate (address, assetId) pair found in outputs: (0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc, 2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe)");
+    });
+
+    test("Multiple AVAX EVMOutput success", (): void => {
+      // Creating 2 outputs with different addresses valid
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(ONEAVAX);
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
+
+      let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX.div(new BN(3)), avaxAssetID);
+      evmOutputs.push(evmOutput);
+      evmOutput = new EVMOutput(cHexAddress2, ONEAVAX.div(new BN(3)), avaxAssetID);
+      evmOutputs.push(evmOutput);
+
+      const importTx: ImportTx = new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
+      expect(importTx).toBeInstanceOf(ImportTx);
+    });
+
+    test("Multiple ANT EVMOutput fail", (): void => {
+      // Creating 2 outputs with the same address and ANT assetID is invalid
+      let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
+      evmOutputs.push(evmOutput);
+      evmOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
+      evmOutputs.push(evmOutput);
+      expect((): void => {
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), [], evmOutputs);
+      }).toThrow("Error - ImportTx: duplicate (address, assetId) pair found in outputs: (0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc, F4MyJcUvq3Rxbqgd4Zs8sUpvwLHApyrp4yxJXe2bAV86Vvp38)");
+    });
+
+    test("Multiple ANT EVMOutput success", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(fee);
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
+
+      let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
+      evmOutputs.push(evmOutput);
+      evmOutput = new EVMOutput(cHexAddress2, ONEAVAX, antAssetID);
+      evmOutputs.push(evmOutput);
+
+      const importTx: ImportTx = new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
+      expect(importTx).toBeInstanceOf(ImportTx);
+    });
+
+    test("Single ANT EVMOutput fail", (): void => {
+      // If the output is a non-avax assetID then don't subtract a fee
+      const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
+      evmOutputs.push(evmOutput);
+      expect((): void => {
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), [], evmOutputs);
+      }).toThrow("Error - 1000000 AVAX required for fee and only 0 AVAX provided");
+    });
+
+    test("Single ANT EVMOutput success", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(fee);
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
+
+      const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
+      evmOutputs.push(evmOutput);
+      const importTx: ImportTx = new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
+      expect(importTx).toBeInstanceOf(ImportTx);
+    });
+
+    test("Single AVAX EVMOutput fail", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(new BN(507));
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
+
+      const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, new BN(0), avaxAssetID);
+      evmOutputs.push(evmOutput);
+      expect((): void => {
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
+      }).toThrow("Error - 1000000 AVAX required for fee and only 507 AVAX provided");
+    });
+
+    test("Single AVAX EVMOutput success", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(ONEAVAX);
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
+
+      const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX.sub(MILLIAVAX), avaxAssetID);
+      evmOutputs.push(evmOutput);
+      const importTx: ImportTx = new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
+      expect(importTx).toBeInstanceOf(ImportTx);
+    });
+  });
+});

--- a/tests/apis/evm/tx.test.ts
+++ b/tests/apis/evm/tx.test.ts
@@ -32,6 +32,10 @@ beforeEach((): void => {
 describe('EVM Transactions', () => {
   describe('ImportTx', () => {
     test("Multiple AVAX EVMOutput fail", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(ONEAVAX);
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
       // Creating 2 outputs with the same address and AVAX assetID is invalid
       let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, avaxAssetID);
       evmOutputs.push(evmOutput);
@@ -39,17 +43,16 @@ describe('EVM Transactions', () => {
       evmOutputs.push(evmOutput);
 
       expect((): void => {
-        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), [], evmOutputs);
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
       }).toThrow("Error - ImportTx: duplicate (address, assetId) pair found in outputs: (0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc, 2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe)");
     });
 
     test("Multiple AVAX EVMOutput success", (): void => {
-      // Creating 2 outputs with different addresses valid
       const outputidx: Buffer = Buffer.from("");
       const input: SECPTransferInput = new SECPTransferInput(ONEAVAX);
       const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
       importedIns.push(xferin);
-
+      // Creating 2 outputs with different addresses valid
       let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX.div(new BN(3)), avaxAssetID);
       evmOutputs.push(evmOutput);
       evmOutput = new EVMOutput(cHexAddress2, ONEAVAX.div(new BN(3)), avaxAssetID);
@@ -60,13 +63,17 @@ describe('EVM Transactions', () => {
     });
 
     test("Multiple ANT EVMOutput fail", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(new BN(507));
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
       // Creating 2 outputs with the same address and ANT assetID is invalid
       let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
       evmOutputs.push(evmOutput);
       evmOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
       evmOutputs.push(evmOutput);
       expect((): void => {
-        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), [], evmOutputs);
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
       }).toThrow("Error - ImportTx: duplicate (address, assetId) pair found in outputs: (0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc, F4MyJcUvq3Rxbqgd4Zs8sUpvwLHApyrp4yxJXe2bAV86Vvp38)");
     });
 
@@ -75,7 +82,6 @@ describe('EVM Transactions', () => {
       const input: SECPTransferInput = new SECPTransferInput(fee);
       const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
       importedIns.push(xferin);
-
       let evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
       evmOutputs.push(evmOutput);
       evmOutput = new EVMOutput(cHexAddress2, ONEAVAX, antAssetID);
@@ -86,20 +92,24 @@ describe('EVM Transactions', () => {
     });
 
     test("Single ANT EVMOutput fail", (): void => {
+      const outputidx: Buffer = Buffer.from("");
+      const input: SECPTransferInput = new SECPTransferInput(new BN(0));
+      const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
+      importedIns.push(xferin);
+
       // If the output is a non-avax assetID then don't subtract a fee
       const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
       evmOutputs.push(evmOutput);
       expect((): void => {
-        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), [], evmOutputs);
+        new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
       }).toThrow("Error - 1000000 AVAX required for fee and only 0 AVAX provided");
     });
 
     test("Single ANT EVMOutput success", (): void => {
       const outputidx: Buffer = Buffer.from("");
-      const input: SECPTransferInput = new SECPTransferInput(fee);
+      const input: SECPTransferInput = new SECPTransferInput(ONEAVAX);
       const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
       importedIns.push(xferin);
-
       const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX, antAssetID);
       evmOutputs.push(evmOutput);
       const importTx: ImportTx = new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);
@@ -124,7 +134,6 @@ describe('EVM Transactions', () => {
       const input: SECPTransferInput = new SECPTransferInput(ONEAVAX);
       const xferin: TransferableInput = new TransferableInput(bintools.cb58Decode(txID), outputidx, bintools.cb58Decode(avaxAssetID), input);
       importedIns.push(xferin);
-
       const evmOutput: EVMOutput = new EVMOutput(cHexAddress1, ONEAVAX.sub(MILLIAVAX), avaxAssetID);
       evmOutputs.push(evmOutput);
       const importTx: ImportTx = new ImportTx(networkID, bintools.cb58Decode(blockchainID), bintools.cb58Decode(sourcechainID), importedIns, evmOutputs);


### PR DESCRIPTION
## Changes

[Perform Apricot Phase 2 Validation on EVM ImportTxs](https://github.com/ava-labs/avalanchejs/pull/187)

## Details

**TLDR**—in EVM `ImportTx` we’re now enforcing:

1. Each `EVMOutput` is unique for an `address` and `assetID`. This means that even if the `ImportTx` has 2 AVAX inputs and 2 ANT inputs it can only have 1 `EVMOutput` for each `assetID` per `address`
2. The importing transaction must burn enough AVAX to cover a transaction fee

### Validating Uniqueness

First, we're [creating a `Map`](https://github.com/ava-labs/avalanchejs/blob/development/src/apis/evm/importtx.ts#L253). Then we're looping over the outputs and mapping addresses to assetIDs. If there are multiple outputs with the same address and assetID then we [throw an error](https://github.com/ava-labs/avalanchejs/blob/development/src/apis/evm/importtx.ts#L261).

```ts
// Example Map
Map(2) {
  '0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC' => [
    'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z',
    'F4MyJcUvq3Rxbqgd4Zs8sUpvwLHApyrp4yxJXe2bAV86Vvp38'
  ],
  '0xecC3B2968B277b837a81A7181e0b94EB1Ca54EdE' => [
    'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z',
    '2Df96yHyhNc3vooieNNhyKwrjEfTsV2ReMo5FKjMpr8vwN4Jqy',
    'SfSXBzDb9GZ9R2uH61qZKe8nxQHW9KERW9Kq9WRe4vHJZRN3e'
  ]
}
```

### Validating Fee

For the fee we're [summing all of the inputs](https://github.com/ava-labs/avalanchejs/blob/development/src/apis/evm/importtx.ts#L273) and then we're [subtracting all of the outputs](https://github.com/ava-labs/avalanchejs/blob/development/src/apis/evm/importtx.ts#L282) which gives us the fee. If the fee is less than the required fee we [throw an error](https://github.com/ava-labs/avalanchejs/blob/development/src/apis/evm/importtx.ts#L290).

## Tests

### Automated

* Single AVAX EVMOutput fail
* Single AVAX EVMOutput success
* Multiple AVAX EVMOutput fail
* Multiple AVAX EVMOutput success
* Single ANT EVMOutput fail
* Single ANT EVMOutput success
* Multiple ANT EVMOutput fail
* Multiple ANT EVMOutput success

### Manual

* [evm-single-avax-import-fail.ts](https://gist.github.com/cgcardona/d3c8390ded1d38d8abe457a0b19b71dc)
* [evm-single-avax-import-success.ts](https://gist.github.com/cgcardona/b082daaf7a81ee2efa4669890517c365)
* [evm-multi-avax-import-fail.ts](https://gist.github.com/cgcardona/0427e1b66e0b2cd382db7561dd671843)
* [evm-multi-avax-import-success.ts](https://gist.github.com/cgcardona/a0cb63e0f8c5d6769014b18e4664a5a9)
* [evm-multi-asset-import-fail.ts](https://gist.github.com/cgcardona/849e7db4471136d9e8fb6ba67b16ea70)
* [evm-multi-asset-import-success.ts](https://gist.github.com/cgcardona/c6a04eeec5d8e9f2ad5d7b47de0521d7)

## Miscellaneous

* Cleaning up the example scripts' syntax
  * Remove commas
  * Remove unneeded `await`s
  * Break multi-component `import` statements across multiple lines

## buildImportTx

In the EVM's `buildImportTx` [create a map of assetIDs to amounts](https://github.com/ava-labs/avalanchejs/blob/078bbd58be2fec4b16f26162358578b512005694/src/apis/evm/utxos.ts#L295). After the fees are paid [for each duplicate assetID increment the existing amount](https://github.com/ava-labs/avalanchejs/blob/078bbd58be2fec4b16f26162358578b512005694/src/apis/evm/utxos.ts#L338-L348). Lastly loop over the map and [create singular EVMOutputs for each assetID](https://github.com/ava-labs/avalanchejs/blob/078bbd58be2fec4b16f26162358578b512005694/src/apis/evm/utxos.ts#L338-L359).