### PR TITLE
add "includePartial" parameter to getBalance method

### DIFF
--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -308,10 +308,11 @@ export class AVMAPI extends JRPCAPI {
    *
    * @param address The address to pull the asset balance from
    * @param assetID The assetID to pull the balance from
+   * @param includePartial If includePartial=false, returns only the balance held solely
    *
    * @returns Promise with the balance of the assetID as a {@link https://github.com/indutny/bn.js/|BN} on the provided address for the blockchain.
    */
-  getBalance = async (address: string, assetID: string): Promise<object> => {
+  getBalance = async (address: string, assetID: string, includePartial: boolean = false): Promise<object> => {
     if (typeof this.parseAddress(address) === "undefined") {
       /* istanbul ignore next */
       throw new AddressError(
@@ -320,7 +321,8 @@ export class AVMAPI extends JRPCAPI {
     }
     const params: GetBalanceInterface = {
       address,
-      assetID
+      assetID,
+      includePartial
     }
     const response: RequestResponseData = await this.callMethod(
       "avm.getBalance",

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -312,7 +312,11 @@ export class AVMAPI extends JRPCAPI {
    *
    * @returns Promise with the balance of the assetID as a {@link https://github.com/indutny/bn.js/|BN} on the provided address for the blockchain.
    */
-  getBalance = async (address: string, assetID: string, includePartial: boolean = false): Promise<object> => {
+  getBalance = async (
+    address: string,
+    assetID: string,
+    includePartial: boolean = false
+  ): Promise<object> => {
     if (typeof this.parseAddress(address) === "undefined") {
       /* istanbul ignore next */
       throw new AddressError(

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -185,6 +185,7 @@ export interface GetAVAXAssetIDInterface {
 export interface GetBalanceInterface {
   address: string
   assetID: string
+  includePartial: boolean
 }
 
 export interface CreateAddressInterface {

--- a/tests/apis/avm/api.test.ts
+++ b/tests/apis/avm/api.test.ts
@@ -359,6 +359,47 @@ describe("AVMAPI", (): void => {
     expect(JSON.stringify(response)).toBe(JSON.stringify(respobj))
   })
 
+  test("getBalance includePartial", async (): Promise<void> => {
+    const balance: BN = new BN("100", 10)
+    const respobj = {
+      balance,
+      utxoIDs: [
+        {
+          txID: "LUriB3W919F84LwPMMw4sm2fZ4Y76Wgb6msaauEY7i1tFNmtv",
+          outputIndex: 0
+        }
+      ]
+    }
+
+    const result: Promise<object> = api.getBalance(addrA, "ATH", true)
+    const payload: object = {
+      result: respobj
+    }
+    const responseObj: HttpResponse = {
+      data: payload
+    }
+
+    const expectedRequestPayload = {
+      id: 1,
+      method: "avm.getBalance",
+      params: {
+        address: addrA,
+        assetID: "ATH",
+        includePartial: true
+      },
+      jsonrpc: "2.0"
+    }
+
+    mockAxios.mockResponse(responseObj)
+    const response: object = await result
+
+    expect(mockAxios.request).toBeCalledWith(
+      expect.objectContaining({ data: JSON.stringify(expectedRequestPayload) })
+    )
+    expect(mockAxios.request).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(response)).toBe(JSON.stringify(respobj))
+  })
+
   test("exportKey", async (): Promise<void> => {
     const key: string = "sdfglvlj2h3v45"
 


### PR DESCRIPTION
This PR adds `includePartial` parameter to `getBalance` api method to be able to query balance for multisig accounts