### PR TITLE
E2e example tests for info, keystore, xchain

### DIFF
--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -1,0 +1,43 @@
+import { Avalanche } from "src"
+
+export function getAvalanche() {
+  if (process.env.AVALANCHEGO_IP == undefined) {
+    throw "undefined environment variable: AVALANCHEGO_IP"
+  }
+  if (process.env.AVALANCHEGO_PORT == undefined) {
+    throw "undefined environment variable: AVALANCHEGO_PORT"
+  }
+  const avalanche = new Avalanche(
+    process.env.AVALANCHEGO_IP,
+    parseInt(process.env.AVALANCHEGO_PORT),
+    "http"
+  )
+  return avalanche
+}
+
+export enum Matcher {
+    toBe,
+    toEqual,
+    toMatch,
+    toThrow,
+}
+
+export function createTests(tests_spec) {
+  for (const [testName, promise, preprocess, matcher, expected] of tests_spec) {
+    test(testName, async () => {
+      if (matcher == Matcher.toBe) {
+        expect(preprocess(await promise())).toBe(expected)
+      }
+      if (matcher == Matcher.toEqual) {
+        expect(preprocess(await promise())).toEqual(expected)
+      }
+      if (matcher == Matcher.toMatch) {
+        expect(preprocess(await promise())).toMatch(expected)
+      }
+      if (matcher == Matcher.toThrow) {
+        await expect(preprocess(promise())).rejects.toThrow(expected)
+      }
+    })
+  }
+}
+

--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -18,6 +18,7 @@ export function getAvalanche() {
 export enum Matcher {
     toBe,
     toEqual,
+    toContain,
     toMatch,
     toThrow,
     toGet,
@@ -31,6 +32,9 @@ export function createTests(tests_spec) {
       }
       if (matcher == Matcher.toEqual) {
         expect(preprocess(await promise())).toEqual(expected)
+      }
+      if (matcher == Matcher.toContain) {
+        expect(preprocess(await promise())).toEqual(expect.arrayContaining(expected))
       }
       if (matcher == Matcher.toMatch) {
         expect(preprocess(await promise())).toMatch(expected)

--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -43,7 +43,7 @@ export function createTests(tests_spec) {
         await expect(preprocess(promise())).rejects.toThrow(expected())
       }
       if (matcher == Matcher.Get) {
-        expected().value = await preprocess(promise())
+        expected().value = preprocess(await promise())
         expect(true).toBe(true)
       }
     })

--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -20,6 +20,7 @@ export enum Matcher {
     toEqual,
     toMatch,
     toThrow,
+    toGet,
 }
 
 export function createTests(tests_spec) {
@@ -36,6 +37,10 @@ export function createTests(tests_spec) {
       }
       if (matcher == Matcher.toThrow) {
         await expect(preprocess(promise())).rejects.toThrow(expected)
+      }
+      if (matcher == Matcher.toGet) {
+        expected.value = await preprocess(promise())
+        expect(true).toBe(true)
       }
     })
   }

--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -28,22 +28,22 @@ export function createTests(tests_spec) {
   for (const [testName, promise, preprocess, matcher, expected] of tests_spec) {
     test(testName, async () => {
       if (matcher == Matcher.toBe) {
-        expect(preprocess(await promise())).toBe(expected)
+        expect(preprocess(await promise())).toBe(expected())
       }
       if (matcher == Matcher.toEqual) {
-        expect(preprocess(await promise())).toEqual(expected)
+        expect(preprocess(await promise())).toEqual(expected())
       }
       if (matcher == Matcher.toContain) {
-        expect(preprocess(await promise())).toEqual(expect.arrayContaining(expected))
+        expect(preprocess(await promise())).toEqual(expect.arrayContaining(expected()))
       }
       if (matcher == Matcher.toMatch) {
-        expect(preprocess(await promise())).toMatch(expected)
+        expect(preprocess(await promise())).toMatch(expected())
       }
       if (matcher == Matcher.toThrow) {
-        await expect(preprocess(promise())).rejects.toThrow(expected)
+        await expect(preprocess(promise())).rejects.toThrow(expected())
       }
       if (matcher == Matcher.Get) {
-        expected.value = await preprocess(promise())
+        expected().value = await preprocess(promise())
         expect(true).toBe(true)
       }
     })

--- a/e2e_tests/e2etestlib.ts
+++ b/e2e_tests/e2etestlib.ts
@@ -21,7 +21,7 @@ export enum Matcher {
     toContain,
     toMatch,
     toThrow,
-    toGet,
+    Get,
 }
 
 export function createTests(tests_spec) {
@@ -42,7 +42,7 @@ export function createTests(tests_spec) {
       if (matcher == Matcher.toThrow) {
         await expect(preprocess(promise())).rejects.toThrow(expected)
       }
-      if (matcher == Matcher.toGet) {
+      if (matcher == Matcher.Get) {
         expected.value = await preprocess(promise())
         expect(true).toBe(true)
       }

--- a/e2e_tests/info_nomock.test.ts
+++ b/e2e_tests/info_nomock.test.ts
@@ -9,15 +9,15 @@ describe("Info", () => {
 
   // test_name          response_promise               resp_fn                 matcher           expected_value/obtained_value
   const tests_spec: any = [
-    ["getBlockchainID", ()=>info.getBlockchainID("X"), (x)=>x,                 Matcher.toBe,     "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed"],
-    ["getNetworkID",    ()=>info.getNetworkID(),       (x)=>x,                 Matcher.toBe,     "12345"],
-    ["getNetworkName",  ()=>info.getNetworkName(),     (x)=>x,                 Matcher.toBe,     "local"],
-    ["getNodeId",       ()=>info.getNodeID(),          (x)=>x,                 Matcher.toBe,     "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"],
-    ["getNodeVersion",  ()=>info.getNodeVersion(),     (x)=>x,                 Matcher.toMatch,  /^avalanche\/\d*\.\d*\.\d*$/],
-    ["isBootstrapped",  ()=>info.isBootstrapped("X"),  (x)=>x,                 Matcher.toBe,     true],
-    ["peers",           ()=>info.peers(),              (x)=>x.length,          Matcher.toBe,     4],
-    ["getTxFee1",       ()=>info.getTxFee(),           (x)=>x.txFee,           Matcher.toEqual,  new BN(1000000000)],
-    ["getTxFee2",       ()=>info.getTxFee(),           (x)=>x.creationTxFee,   Matcher.toEqual,  new BN(1000000)],
+    ["getBlockchainID", ()=>info.getBlockchainID("X"), (x)=>x,                 Matcher.toBe,     ()=>"2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed"],
+    ["getNetworkID",    ()=>info.getNetworkID(),       (x)=>x,                 Matcher.toBe,     ()=>"12345"],
+    ["getNetworkName",  ()=>info.getNetworkName(),     (x)=>x,                 Matcher.toBe,     ()=>"local"],
+    ["getNodeId",       ()=>info.getNodeID(),          (x)=>x,                 Matcher.toBe,     ()=>"NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"],
+    ["getNodeVersion",  ()=>info.getNodeVersion(),     (x)=>x,                 Matcher.toMatch,  ()=>/^avalanche\/\d*\.\d*\.\d*$/],
+    ["isBootstrapped",  ()=>info.isBootstrapped("X"),  (x)=>x,                 Matcher.toBe,     ()=>true],
+    ["peers",           ()=>info.peers(),              (x)=>x.length,          Matcher.toBe,     ()=>4],
+    ["getTxFee1",       ()=>info.getTxFee(),           (x)=>x.txFee,           Matcher.toEqual,  ()=>new BN(1000000000)],
+    ["getTxFee2",       ()=>info.getTxFee(),           (x)=>x.creationTxFee,   Matcher.toEqual,  ()=>new BN(1000000)],
   ]
 
   createTests(tests_spec)

--- a/e2e_tests/info_nomock.test.ts
+++ b/e2e_tests/info_nomock.test.ts
@@ -5,10 +5,9 @@ import BN from "bn.js"
 describe("Info", () => {
 
   const avalanche = getAvalanche()
-
   let info = avalanche.Info()
 
-  // test_name          response_promise               resp_fn                 matcher           expected_value
+  // test_name          response_promise               resp_fn                 matcher           expected_value/obtained_value
   const tests_spec: any = [
     ["getBlockchainID", ()=>info.getBlockchainID("X"), (x)=>x,                 Matcher.toBe,     "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed"],
     ["getNetworkID",    ()=>info.getNetworkID(),       (x)=>x,                 Matcher.toBe,     "12345"],
@@ -16,8 +15,8 @@ describe("Info", () => {
     ["getNodeId",       ()=>info.getNodeID(),          (x)=>x,                 Matcher.toBe,     "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"],
     ["getNodeVersion",  ()=>info.getNodeVersion(),     (x)=>x,                 Matcher.toMatch,  /^avalanche\/\d*\.\d*\.\d*$/],
     ["isBootstrapped",  ()=>info.isBootstrapped("X"),  (x)=>x,                 Matcher.toBe,     true],
-    ["peers",           ()=>info.peers(),              (x)=>x.length,          Matcher.toBe,     0],
-    ["getTxFee1",       ()=>info.getTxFee(),           (x)=>x.txFee,           Matcher.toEqual,  new BN(1000000)],
+    ["peers",           ()=>info.peers(),              (x)=>x.length,          Matcher.toBe,     4],
+    ["getTxFee1",       ()=>info.getTxFee(),           (x)=>x.txFee,           Matcher.toEqual,  new BN(1000000000)],
     ["getTxFee2",       ()=>info.getTxFee(),           (x)=>x.creationTxFee,   Matcher.toEqual,  new BN(1000000)],
   ]
 

--- a/e2e_tests/info_nomock.test.ts
+++ b/e2e_tests/info_nomock.test.ts
@@ -1,40 +1,26 @@
-import { Avalanche } from "src"
+import { getAvalanche, createTests, Matcher } from "./e2etestlib"
 import { InfoAPI } from "src/apis/info/api"
 import BN from "bn.js"
 
 describe("Info", () => {
 
-  if (process.env.AVALANCHEGO_IP == undefined) {
-    throw "undefined environment variable: AVALANCHEGO_IP"
-  }
-  if (process.env.AVALANCHEGO_PORT == undefined) {
-    throw "undefined environment variable: AVALANCHEGO_PORT"
-  }
+  const avalanche = getAvalanche()
 
-  const avalanche = new Avalanche(
-    process.env.AVALANCHEGO_IP,
-    parseInt(process.env.AVALANCHEGO_PORT),
-    "http"
-  )
   let info = avalanche.Info()
 
-  const defs: any = [
-    ["getBlockchainID", info.getBlockchainID("X"), (x) => x,               "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed"],
-    ["getNetworkID",    info.getNetworkID(),       (x) => x,               "12345"],
-    ["getTxFee1",       info.getTxFee(),           (x) => x.txFee,         new BN("1000000000")],
-    ["getTxFee2",       info.getTxFee(),           (x) => x.creationTxFee, new BN("1000000")],
-    ["getNetworkName",  info.getNetworkName(),     (x) => x,               "local"],
-    ["getNodeId",       info.getNodeID(),          (x) => x,               "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"],
-    ["getNodeVersion",  info.getNodeVersion(),     (x) => x,               "avalanche/1.4.12"],
-    ["isBootstrapped",  info.isBootstrapped("X"),  (x) => x,               true],
-    ["peers",           info.peers(),              (x) => x.length,        4],
+  // test_name          response_promise               resp_fn                 matcher           expected_value
+  const tests_spec: any = [
+    ["getBlockchainID", ()=>info.getBlockchainID("X"), (x)=>x,                 Matcher.toBe,     "2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed"],
+    ["getNetworkID",    ()=>info.getNetworkID(),       (x)=>x,                 Matcher.toBe,     "12345"],
+    ["getNetworkName",  ()=>info.getNetworkName(),     (x)=>x,                 Matcher.toBe,     "local"],
+    ["getNodeId",       ()=>info.getNodeID(),          (x)=>x,                 Matcher.toBe,     "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"],
+    ["getNodeVersion",  ()=>info.getNodeVersion(),     (x)=>x,                 Matcher.toMatch,  /^avalanche\/\d*\.\d*\.\d*$/],
+    ["isBootstrapped",  ()=>info.isBootstrapped("X"),  (x)=>x,                 Matcher.toBe,     true],
+    ["peers",           ()=>info.peers(),              (x)=>x.length,          Matcher.toBe,     0],
+    ["getTxFee1",       ()=>info.getTxFee(),           (x)=>x.txFee,           Matcher.toEqual,  new BN(1000000)],
+    ["getTxFee2",       ()=>info.getTxFee(),           (x)=>x.creationTxFee,   Matcher.toEqual,  new BN(1000000)],
   ]
 
-  for (const e of defs) {
-    test(e[0], async () => {
-      const result = e[1]
-      const response = await result
-      expect(e[2](response)).toStrictEqual(e[3])
-    })
-  }
+  createTests(tests_spec)
+
 })

--- a/e2e_tests/keystore_nomock.test.ts
+++ b/e2e_tests/keystore_nomock.test.ts
@@ -1,0 +1,33 @@
+import { getAvalanche, createTests, Matcher } from "./e2etestlib"
+import { KeystoreAPI } from "src/apis/keystore/api"
+
+describe("Keystore", (): void => {
+
+  const username: string = "avalancheJsUser"
+  const username2: string = "avalancheJsUser2"
+  const password: string = "avalancheJsP1ssw4rd"
+
+  const avalanche = getAvalanche()
+
+  const keystore = new KeystoreAPI(avalanche)
+
+  // test_name             response_promise                              resp_fn  matcher           expected_value
+  const tests_spec: any = [
+    ["createUserWeakPass", ()=>keystore.createUser(username, "weak"),    (x)=>x,  Matcher.toThrow,  "password is too weak"],
+    ["createUser",         ()=>keystore.createUser(username, password),  (x)=>x,  Matcher.toBe,     true],
+    ["createRepeatedUser", ()=>keystore.createUser(username, password),  (x)=>x,  Matcher.toThrow,  "user already exists: " + username],
+    ["listUsers",          ()=>keystore.listUsers(),                     (x)=>x,  Matcher.toEqual,  [username]],
+    ["exportUser",         ()=>keystore.exportUser(username, password),  (x)=>x,  Matcher.toMatch,  /\w{78}/],
+    ["exportImportUser",   ()=>(async () => {
+                             let exported = await keystore.exportUser(username, password);
+                             return await keystore.importUser(username2, exported, password);
+                           })(),                                         (x)=>x,  Matcher.toBe,     true],
+    ["listUsers2",         ()=>keystore.listUsers(),                     (x)=>x,  Matcher.toEqual,  [username,username2]],
+    ["deleteUser",         ()=>keystore.deleteUser(username, password),  (x)=>x,  Matcher.toBe,     true],
+    ["deleteUser2",        ()=>keystore.deleteUser(username2, password), (x)=>x,  Matcher.toBe,     true],
+  ]
+
+  createTests(tests_spec)
+
+})
+

--- a/e2e_tests/keystore_nomock.test.ts
+++ b/e2e_tests/keystore_nomock.test.ts
@@ -15,22 +15,22 @@ describe("Keystore", (): void => {
 
   // test_name             response_promise                              resp_fn  matcher           expected_value/obtained_value
   const tests_spec: any = [
-    ["createUserWeakPass", ()=>keystore.createUser(username1, "weak"),    (x)=>x,  Matcher.toThrow,  "password is too weak"],
-    ["createUser",         ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toBe,     true],
-    ["createRepeatedUser", ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toThrow,  "user already exists: " + username1],
-    ["listUsers",          ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toEqual,  [username1]],
-    ["exportUser",         ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toMatch,  /\w{78}/],
-    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toGet,    exportedUser],
+    ["createUserWeakPass", ()=>keystore.createUser(username1, "weak"),    (x)=>x,  Matcher.toThrow,   "password is too weak"],
+    ["createUser",         ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toBe,      true],
+    ["createRepeatedUser", ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toThrow,   "user already exists: " + username1],
+    ["listUsers",          ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, [username1]],
+    ["exportUser",         ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toMatch,   /\w{78}/],
+    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toGet,     exportedUser],
     ["importUser",         ()=>keystore.importUser(username2, exportedUser.value, password),
-                                                                          (x)=>x,  Matcher.toBe,     true],
+                                                                          (x)=>x,  Matcher.toBe,      true],
     ["exportImportUser",   ()=>(async () => {
                              let exported = await keystore.exportUser(username1, password);
                              return await keystore.importUser(username3, exported, password);
-                           })(),                                          (x)=>x,  Matcher.toBe,     true],
-    ["listUsers2",         ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toEqual,  [username1,username2,username3]],
-    ["deleteUser1",        ()=>keystore.deleteUser(username1, password),  (x)=>x,  Matcher.toBe,     true],
-    ["deleteUser2",        ()=>keystore.deleteUser(username2, password),  (x)=>x,  Matcher.toBe,     true],
-    ["deleteUser3",        ()=>keystore.deleteUser(username3, password),  (x)=>x,  Matcher.toBe,     true],
+                           })(),                                          (x)=>x,  Matcher.toBe,      true],
+    ["listUsers2",         ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, [username1,username2,username3]],
+    ["deleteUser1",        ()=>keystore.deleteUser(username1, password),  (x)=>x,  Matcher.toBe,      true],
+    ["deleteUser2",        ()=>keystore.deleteUser(username2, password),  (x)=>x,  Matcher.toBe,      true],
+    ["deleteUser3",        ()=>keystore.deleteUser(username3, password),  (x)=>x,  Matcher.toBe,      true],
   ]
 
   createTests(tests_spec)

--- a/e2e_tests/keystore_nomock.test.ts
+++ b/e2e_tests/keystore_nomock.test.ts
@@ -15,22 +15,22 @@ describe("Keystore", (): void => {
 
   // test_name             response_promise                              resp_fn  matcher           expected_value/obtained_value
   const tests_spec: any = [
-    ["createUserWeakPass", ()=>keystore.createUser(username1, "weak"),    (x)=>x,  Matcher.toThrow,   "password is too weak"],
-    ["createUser",         ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toBe,      true],
-    ["createRepeatedUser", ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toThrow,   "user already exists: " + username1],
-    ["listUsers",          ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, [username1]],
-    ["exportUser",         ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toMatch,   /\w{78}/],
-    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.Get,     exportedUser],
+    ["createUserWeakPass", ()=>keystore.createUser(username1, "weak"),    (x)=>x,  Matcher.toThrow,   ()=>"password is too weak"],
+    ["createUser",         ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toBe,      ()=>true],
+    ["createRepeatedUser", ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toThrow,   ()=>"user already exists: " + username1],
+    ["listUsers",          ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, ()=>[username1]],
+    ["exportUser",         ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toMatch,   ()=>/\w{78}/],
+    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.Get,     ()=>exportedUser],
     ["importUser",         ()=>keystore.importUser(username2, exportedUser.value, password),
-                                                                          (x)=>x,  Matcher.toBe,      true],
+                                                                          (x)=>x,  Matcher.toBe,      ()=>true],
     ["exportImportUser",   ()=>(async () => {
                              let exported = await keystore.exportUser(username1, password);
                              return await keystore.importUser(username3, exported, password);
-                           })(),                                          (x)=>x,  Matcher.toBe,      true],
-    ["listUsers2",         ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, [username1,username2,username3]],
-    ["deleteUser1",        ()=>keystore.deleteUser(username1, password),  (x)=>x,  Matcher.toBe,      true],
-    ["deleteUser2",        ()=>keystore.deleteUser(username2, password),  (x)=>x,  Matcher.toBe,      true],
-    ["deleteUser3",        ()=>keystore.deleteUser(username3, password),  (x)=>x,  Matcher.toBe,      true],
+                           })(),                                          (x)=>x,  Matcher.toBe,      ()=>true],
+    ["listUsers2",         ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, ()=>[username1,username2,username3]],
+    ["deleteUser1",        ()=>keystore.deleteUser(username1, password),  (x)=>x,  Matcher.toBe,      ()=>true],
+    ["deleteUser2",        ()=>keystore.deleteUser(username2, password),  (x)=>x,  Matcher.toBe,      ()=>true],
+    ["deleteUser3",        ()=>keystore.deleteUser(username3, password),  (x)=>x,  Matcher.toBe,      ()=>true],
   ]
 
   createTests(tests_spec)

--- a/e2e_tests/keystore_nomock.test.ts
+++ b/e2e_tests/keystore_nomock.test.ts
@@ -20,7 +20,7 @@ describe("Keystore", (): void => {
     ["createRepeatedUser", ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toThrow,   "user already exists: " + username1],
     ["listUsers",          ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toContain, [username1]],
     ["exportUser",         ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toMatch,   /\w{78}/],
-    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toGet,     exportedUser],
+    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.Get,     exportedUser],
     ["importUser",         ()=>keystore.importUser(username2, exportedUser.value, password),
                                                                           (x)=>x,  Matcher.toBe,      true],
     ["exportImportUser",   ()=>(async () => {

--- a/e2e_tests/keystore_nomock.test.ts
+++ b/e2e_tests/keystore_nomock.test.ts
@@ -3,28 +3,34 @@ import { KeystoreAPI } from "src/apis/keystore/api"
 
 describe("Keystore", (): void => {
 
-  const username: string = "avalancheJsUser"
+  const username1: string = "avalancheJsUser1"
   const username2: string = "avalancheJsUser2"
+  const username3: string = "avalancheJsUser3"
   const password: string = "avalancheJsP1ssw4rd"
 
-  const avalanche = getAvalanche()
+  let exportedUser = {value: ""}
 
+  const avalanche = getAvalanche()
   const keystore = new KeystoreAPI(avalanche)
 
-  // test_name             response_promise                              resp_fn  matcher           expected_value
+  // test_name             response_promise                              resp_fn  matcher           expected_value/obtained_value
   const tests_spec: any = [
-    ["createUserWeakPass", ()=>keystore.createUser(username, "weak"),    (x)=>x,  Matcher.toThrow,  "password is too weak"],
-    ["createUser",         ()=>keystore.createUser(username, password),  (x)=>x,  Matcher.toBe,     true],
-    ["createRepeatedUser", ()=>keystore.createUser(username, password),  (x)=>x,  Matcher.toThrow,  "user already exists: " + username],
-    ["listUsers",          ()=>keystore.listUsers(),                     (x)=>x,  Matcher.toEqual,  [username]],
-    ["exportUser",         ()=>keystore.exportUser(username, password),  (x)=>x,  Matcher.toMatch,  /\w{78}/],
+    ["createUserWeakPass", ()=>keystore.createUser(username1, "weak"),    (x)=>x,  Matcher.toThrow,  "password is too weak"],
+    ["createUser",         ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toBe,     true],
+    ["createRepeatedUser", ()=>keystore.createUser(username1, password),  (x)=>x,  Matcher.toThrow,  "user already exists: " + username1],
+    ["listUsers",          ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toEqual,  [username1]],
+    ["exportUser",         ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toMatch,  /\w{78}/],
+    ["getExportedUser",    ()=>keystore.exportUser(username1, password),  (x)=>x,  Matcher.toGet,    exportedUser],
+    ["importUser",         ()=>keystore.importUser(username2, exportedUser.value, password),
+                                                                          (x)=>x,  Matcher.toBe,     true],
     ["exportImportUser",   ()=>(async () => {
-                             let exported = await keystore.exportUser(username, password);
-                             return await keystore.importUser(username2, exported, password);
-                           })(),                                         (x)=>x,  Matcher.toBe,     true],
-    ["listUsers2",         ()=>keystore.listUsers(),                     (x)=>x,  Matcher.toEqual,  [username,username2]],
-    ["deleteUser",         ()=>keystore.deleteUser(username, password),  (x)=>x,  Matcher.toBe,     true],
-    ["deleteUser2",        ()=>keystore.deleteUser(username2, password), (x)=>x,  Matcher.toBe,     true],
+                             let exported = await keystore.exportUser(username1, password);
+                             return await keystore.importUser(username3, exported, password);
+                           })(),                                          (x)=>x,  Matcher.toBe,     true],
+    ["listUsers2",         ()=>keystore.listUsers(),                      (x)=>x,  Matcher.toEqual,  [username1,username2,username3]],
+    ["deleteUser1",        ()=>keystore.deleteUser(username1, password),  (x)=>x,  Matcher.toBe,     true],
+    ["deleteUser2",        ()=>keystore.deleteUser(username2, password),  (x)=>x,  Matcher.toBe,     true],
+    ["deleteUser3",        ()=>keystore.deleteUser(username3, password),  (x)=>x,  Matcher.toBe,     true],
   ]
 
   createTests(tests_spec)

--- a/e2e_tests/xchain_nomock.test.ts
+++ b/e2e_tests/xchain_nomock.test.ts
@@ -1,9 +1,11 @@
 import { getAvalanche, createTests, Matcher } from "./e2etestlib"
 import { KeystoreAPI } from "src/apis/keystore/api"
+import BN from "bn.js"
 
 describe("XChain", (): void => {
 
   let tx = {value: ""}
+  let asset = {value: ""}
   let addrB = {value: ""}
   let addrC = {value: ""}
 
@@ -19,52 +21,42 @@ describe("XChain", (): void => {
   const whaleAddr: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
   const key: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 
-  // test_name        response_promise                                   resp_fn          matcher           expected_value/obtained_value
+  // test_name        response_promise                            resp_fn          matcher           expected_value/obtained_value
   const tests_spec: any = [
-    ["createUser",    ()=>keystore.createUser(user, passwd),  (x)=>x,  Matcher.toBe,      ()=>true],
-    ["createaddrB",   ()=>xchain.createAddress(user, passwd), (x)=>x,  Matcher.Get,       ()=>addrB],
-    ["createaddrB",   ()=>xchain.createAddress(user, passwd), (x)=>x,  Matcher.Get,       ()=>addrC],
+    ["createUser",    ()=>keystore.createUser(user, passwd),      (x)=>x,                  Matcher.toBe,     ()=>true],
+    ["createaddrB",   ()=>xchain.createAddress(user, passwd),     (x)=>x,                  Matcher.Get,      ()=>addrB],
+    ["createaddrB",   ()=>xchain.createAddress(user, passwd),     (x)=>x,                  Matcher.Get,      ()=>addrC],
     ["incorrectUser", ()=>xchain.send(badUser, passwd, "AVAX", 10, addrB.value, [addrC.value], addrB.value, memo),
-                                                                         (x)=>x,          Matcher.toThrow,   ()=>`problem retrieving user: incorrect password for user "${badUser}"`],
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>`problem retrieving user: incorrect password for user "${badUser}"`],
     ["incorrectPass", ()=>xchain.send(user, badPass, "AVAX", 10, addrB.value, [addrC.value], addrB.value, memo),
-                                                                         (x)=>x,          Matcher.toThrow,   ()=>`problem retrieving user: incorrect password for user "${user}"`],
-    ["getBalance",    ()=>xchain.getBalance(whaleAddr, "AVAX"),          (x)=>x.balance,  Matcher.toBe,      ()=>"300000000000000000"],
-    ["getBalance2",   ()=>xchain.getBalance(whaleAddr, "AVAX"),         (x)=>x.utxoIDs[0].txID,  Matcher.toBe,     ()=>"2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"],
-    [
-      "importKey",
-      ()=>xchain.importKey(user, passwd, key),
-      (x)=>x,
-      Matcher.toBe,
-      ()=>whaleAddr
-    ],
-    [
-      "send",
-      ()=>xchain.send(user, passwd, "AVAX", 10, addrB.value, [whaleAddr], whaleAddr, memo),
-      (x)=>x.txID,
-      Matcher.Get,
-      ()=>tx
-    ],
-    [
-      "sendMultiple",
-      ()=>xchain.sendMultiple(user, passwd, [{ assetID: "AVAX", amount: 10, to: addrB.value}, { assetID: "AVAX", amount: 20, to: addrC.value}], [whaleAddr], whaleAddr, memo),
-      (x)=>x.txID,
-      Matcher.Get,
-      ()=>tx
-    ],
-    [
-      "listAddrs",
-      ()=>xchain.listAddresses(user, passwd),
-      (x)=>x.sort(),
-      Matcher.toEqual,
-      ()=>[whaleAddr, addrB.value, addrC.value].sort()
-    ],
-    [
-      "exportKey",
-      ()=>xchain.exportKey(user, passwd, addrB.value),
-      (x)=>x,
-      Matcher.toMatch,
-      ()=>/PrivateKey-\w{50}/
-    ],
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>`problem retrieving user: incorrect password for user "${user}"`],
+    ["getBalance",    ()=>xchain.getBalance(whaleAddr, "AVAX"),   (x)=>x.balance,          Matcher.toBe,     ()=>"300000000000000000"],
+    ["getBalance2",   ()=>xchain.getBalance(whaleAddr, "AVAX"),   (x)=>x.utxoIDs[0].txID,  Matcher.toBe,     ()=>"2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"],
+    [ "importKey",    ()=>xchain.importKey(user, passwd, key),    (x)=>x,                  Matcher.toBe,     ()=>whaleAddr ],
+    [ "send",         ()=>xchain.send(user, passwd, "AVAX", 10, addrB.value, [whaleAddr], whaleAddr, memo), 
+                                                                  (x)=>x.txID,             Matcher.Get,      ()=>tx ],
+    [ "sendMultiple", ()=>xchain.sendMultiple(user, passwd, [{ assetID: "AVAX", amount: 10, to: addrB.value}, { assetID: "AVAX", amount: 20, to: addrC.value}], [whaleAddr], whaleAddr, memo),                           (x)=>x.txID,             Matcher.Get,      ()=>tx ],
+    [ "listAddrs",    ()=>xchain.listAddresses(user, passwd),     (x)=>x.sort(),           Matcher.toEqual,  ()=>[whaleAddr, addrB.value, addrC.value].sort() ],
+    [ "exportKey",    ()=>xchain.exportKey(user, passwd, addrB.value), 
+                                                                  (x)=>x,                  Matcher.toMatch,  ()=>/PrivateKey-\w*/ ],
+    [ "export",       ()=>xchain.export(user, passwd, "C"+addrB.value.substring(1), new BN(10), "AVAX"),
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"couldn't unmarshal an argument"],
+    [ "exportAVAX",   ()=>xchain.exportAVAX(user, passwd, "C"+addrB.value.substring(1), new BN(10)),
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"couldn't unmarshal an argument"],
+    [ "import",       ()=>xchain.import(user, passwd, addrB.value, "C"),
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"problem issuing transaction: no import inputs"],
+    [ "importAVAX",   ()=>xchain.importAVAX(user, passwd, addrB.value, "P"),
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"problem issuing transaction: no import inputs"],
+    [ "createFixed",  ()=>xchain.createFixedCapAsset(user, passwd, "Some Coin", "SCC", 0, [{address: whaleAddr, amount: "10000"}]),
+                                                                  (x)=>x,                  Matcher.Get,      ()=>asset],
+    [ "createVar",    ()=>xchain.createVariableCapAsset(user, passwd, "Some Coin", "SCC", 0, [{minters: [whaleAddr], threshold: 1}]),
+                                                                  (x)=>x,                  Matcher.Get,      ()=>asset],
+    [ "mint",         ()=>xchain.mint(user, passwd, 1500, asset.value, addrB.value, [whaleAddr]),
+                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"couldn't unmarshal an argument"],
+    [ "getTx",        ()=>xchain.getTx(tx.value),                 (x)=>x,                  Matcher.toMatch,  ()=>/\w+/],
+    [ "getTxStatus",  ()=>xchain.getTxStatus(tx.value),           (x)=>x,                  Matcher.toBe,     ()=>"Processing"],
+    [ "getAssetDesc", ()=>xchain.getAssetDescription(asset.value),(x)=>[x.name, x.symbol], Matcher.toEqual,  ()=>["Some Coin", "SCC"]],
+
   ]
 
   createTests(tests_spec)

--- a/e2e_tests/xchain_nomock.test.ts
+++ b/e2e_tests/xchain_nomock.test.ts
@@ -1,0 +1,72 @@
+import { getAvalanche, createTests, Matcher } from "./e2etestlib"
+import { KeystoreAPI } from "src/apis/keystore/api"
+
+describe("XChain", (): void => {
+
+  let tx = {value: ""}
+  let addrB = {value: ""}
+  let addrC = {value: ""}
+
+  const avalanche = getAvalanche()
+  const xchain = avalanche.XChain()
+  const keystore = new KeystoreAPI(avalanche)
+
+  const user: string = "avalancheJsXChainUser"
+  const passwd: string = "avalancheJsP1ssw4rd"
+  const badUser: string = "asdfasdfsa"
+  const badPass: string = "pass"
+  const memo: string = "hello world"
+  const whaleAddr: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+  const key: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
+
+  // test_name        response_promise                                   resp_fn          matcher           expected_value/obtained_value
+  const tests_spec: any = [
+    ["createUser",    ()=>keystore.createUser(user, passwd),  (x)=>x,  Matcher.toBe,      ()=>true],
+    ["createaddrB",   ()=>xchain.createAddress(user, passwd), (x)=>x,  Matcher.Get,       ()=>addrB],
+    ["createaddrB",   ()=>xchain.createAddress(user, passwd), (x)=>x,  Matcher.Get,       ()=>addrC],
+    ["incorrectUser", ()=>xchain.send(badUser, passwd, "AVAX", 10, addrB.value, [addrC.value], addrB.value, memo),
+                                                                         (x)=>x,          Matcher.toThrow,   ()=>`problem retrieving user: incorrect password for user "${badUser}"`],
+    ["incorrectPass", ()=>xchain.send(user, badPass, "AVAX", 10, addrB.value, [addrC.value], addrB.value, memo),
+                                                                         (x)=>x,          Matcher.toThrow,   ()=>`problem retrieving user: incorrect password for user "${user}"`],
+    ["getBalance",    ()=>xchain.getBalance(whaleAddr, "AVAX"),          (x)=>x.balance,  Matcher.toBe,      ()=>"300000000000000000"],
+    ["getBalance2",   ()=>xchain.getBalance(whaleAddr, "AVAX"),         (x)=>x.utxoIDs[0].txID,  Matcher.toBe,     ()=>"2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"],
+    [
+      "importKey",
+      ()=>xchain.importKey(user, passwd, key),
+      (x)=>x,
+      Matcher.toBe,
+      ()=>whaleAddr
+    ],
+    [
+      "send",
+      ()=>xchain.send(user, passwd, "AVAX", 10, addrB.value, [whaleAddr], whaleAddr, memo),
+      (x)=>x.txID,
+      Matcher.Get,
+      ()=>tx
+    ],
+    [
+      "sendMultiple",
+      ()=>xchain.sendMultiple(user, passwd, [{ assetID: "AVAX", amount: 10, to: addrB.value}, { assetID: "AVAX", amount: 20, to: addrC.value}], [whaleAddr], whaleAddr, memo),
+      (x)=>x.txID,
+      Matcher.Get,
+      ()=>tx
+    ],
+    [
+      "listAddrs",
+      ()=>xchain.listAddresses(user, passwd),
+      (x)=>x.sort(),
+      Matcher.toEqual,
+      ()=>[whaleAddr, addrB.value, addrC.value].sort()
+    ],
+    [
+      "exportKey",
+      ()=>xchain.exportKey(user, passwd, addrB.value),
+      (x)=>x,
+      Matcher.toMatch,
+      ()=>/PrivateKey-\w{50}/
+    ],
+  ]
+
+  createTests(tests_spec)
+
+})


### PR DESCRIPTION
- posible way to specify a common test pattern, that always contain this data (spec):
  - testname
  - promise to execute (api call)
  - transformation to apply to promise execution's result, to get obtained value
  - matcher to use to compare obtained vs expected (toBe, toEqual, toContain, toMatch, toThrow, etc)
  - expected value
- a "matcher" Get is also used when needed: instead of comparing with an expected value, it is given an object for which its value attribute is set to the transformation applied to the promise execution result. Used to get data from avalanchego to be used in later tests.
- e2etestlib.ts: getAvalanche() to get avalanche node connection, Matcher to choose expect matcher, createTests() to create the jest tests from a array of specs
- the generated tests are executed in sequence and in order of definition
- the testsuites are executed in sequence but without a specific order (using yarn test -i)
- the sequence and order in test execution enable to create state in the avalanche node, and to get values from the avalanche node, to be used in later tests
- the promise to execute, and the expected value are enclosed in a arrow function, to avoid promise executing before test execution, and to enable object evaluation during test execution

Note in xchain test, there are 3 calls that give unexpected unmarshalling errors: export, exportAVAX, mint. This is problaby related to the amounts being sent to avalanchego as hex strings. Some problem with BN transformation to JSON.
