### PR TITLE
Deprecate avmexportavax

### DIFF
--- a/e2e_tests/xchain_nomock.test.ts
+++ b/e2e_tests/xchain_nomock.test.ts
@@ -3,11 +3,10 @@ import { KeystoreAPI } from "src/apis/keystore/api"
 import BN from "bn.js"
 
 describe("XChain", (): void => {
-
-  let tx = {value: ""}
-  let asset = {value: ""}
-  let addrB = {value: ""}
-  let addrC = {value: ""}
+  let tx = { value: "" }
+  let asset = { value: "" }
+  let addrB = { value: "" }
+  let addrC = { value: "" }
 
   const avalanche = getAvalanche()
   const xchain = avalanche.XChain()
@@ -19,46 +18,227 @@ describe("XChain", (): void => {
   const badPass: string = "pass"
   const memo: string = "hello world"
   const whaleAddr: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
-  const key: string = "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
+  const key: string =
+    "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN"
 
   // test_name        response_promise                            resp_fn          matcher           expected_value/obtained_value
   const tests_spec: any = [
-    ["createUser",    ()=>keystore.createUser(user, passwd),      (x)=>x,                  Matcher.toBe,     ()=>true],
-    ["createaddrB",   ()=>xchain.createAddress(user, passwd),     (x)=>x,                  Matcher.Get,      ()=>addrB],
-    ["createaddrB",   ()=>xchain.createAddress(user, passwd),     (x)=>x,                  Matcher.Get,      ()=>addrC],
-    ["incorrectUser", ()=>xchain.send(badUser, passwd, "AVAX", 10, addrB.value, [addrC.value], addrB.value, memo),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>`problem retrieving user: incorrect password for user "${badUser}"`],
-    ["incorrectPass", ()=>xchain.send(user, badPass, "AVAX", 10, addrB.value, [addrC.value], addrB.value, memo),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>`problem retrieving user: incorrect password for user "${user}"`],
-    ["getBalance",    ()=>xchain.getBalance(whaleAddr, "AVAX"),   (x)=>x.balance,          Matcher.toBe,     ()=>"300000000000000000"],
-    ["getBalance2",   ()=>xchain.getBalance(whaleAddr, "AVAX"),   (x)=>x.utxoIDs[0].txID,  Matcher.toBe,     ()=>"2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"],
-    [ "importKey",    ()=>xchain.importKey(user, passwd, key),    (x)=>x,                  Matcher.toBe,     ()=>whaleAddr ],
-    [ "send",         ()=>xchain.send(user, passwd, "AVAX", 10, addrB.value, [whaleAddr], whaleAddr, memo), 
-                                                                  (x)=>x.txID,             Matcher.Get,      ()=>tx ],
-    [ "sendMultiple", ()=>xchain.sendMultiple(user, passwd, [{ assetID: "AVAX", amount: 10, to: addrB.value}, { assetID: "AVAX", amount: 20, to: addrC.value}], [whaleAddr], whaleAddr, memo),                           (x)=>x.txID,             Matcher.Get,      ()=>tx ],
-    [ "listAddrs",    ()=>xchain.listAddresses(user, passwd),     (x)=>x.sort(),           Matcher.toEqual,  ()=>[whaleAddr, addrB.value, addrC.value].sort() ],
-    [ "exportKey",    ()=>xchain.exportKey(user, passwd, addrB.value), 
-                                                                  (x)=>x,                  Matcher.toMatch,  ()=>/PrivateKey-\w*/ ],
-    [ "export",       ()=>xchain.export(user, passwd, "C"+addrB.value.substring(1), new BN(10), "AVAX"),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"couldn't unmarshal an argument"],
-    [ "exportAVAX",   ()=>xchain.exportAVAX(user, passwd, "C"+addrB.value.substring(1), new BN(10)),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"couldn't unmarshal an argument"],
-    [ "import",       ()=>xchain.import(user, passwd, addrB.value, "C"),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"problem issuing transaction: no import inputs"],
-    [ "importAVAX",   ()=>xchain.importAVAX(user, passwd, addrB.value, "P"),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"problem issuing transaction: no import inputs"],
-    [ "createFixed",  ()=>xchain.createFixedCapAsset(user, passwd, "Some Coin", "SCC", 0, [{address: whaleAddr, amount: "10000"}]),
-                                                                  (x)=>x,                  Matcher.Get,      ()=>asset],
-    [ "createVar",    ()=>xchain.createVariableCapAsset(user, passwd, "Some Coin", "SCC", 0, [{minters: [whaleAddr], threshold: 1}]),
-                                                                  (x)=>x,                  Matcher.Get,      ()=>asset],
-    [ "mint",         ()=>xchain.mint(user, passwd, 1500, asset.value, addrB.value, [whaleAddr]),
-                                                                  (x)=>x,                  Matcher.toThrow,  ()=>"couldn't unmarshal an argument"],
-    [ "getTx",        ()=>xchain.getTx(tx.value),                 (x)=>x,                  Matcher.toMatch,  ()=>/\w+/],
-    [ "getTxStatus",  ()=>xchain.getTxStatus(tx.value),           (x)=>x,                  Matcher.toBe,     ()=>"Processing"],
-    [ "getAssetDesc", ()=>xchain.getAssetDescription(asset.value),(x)=>[x.name, x.symbol], Matcher.toEqual,  ()=>["Some Coin", "SCC"]],
-
+    [
+      "createUser",
+      () => keystore.createUser(user, passwd),
+      (x) => x,
+      Matcher.toBe,
+      () => true
+    ],
+    [
+      "createaddrB",
+      () => xchain.createAddress(user, passwd),
+      (x) => x,
+      Matcher.Get,
+      () => addrB
+    ],
+    [
+      "createaddrB",
+      () => xchain.createAddress(user, passwd),
+      (x) => x,
+      Matcher.Get,
+      () => addrC
+    ],
+    [
+      "incorrectUser",
+      () =>
+        xchain.send(
+          badUser,
+          passwd,
+          "AVAX",
+          10,
+          addrB.value,
+          [addrC.value],
+          addrB.value,
+          memo
+        ),
+      (x) => x,
+      Matcher.toThrow,
+      () => `problem retrieving user: incorrect password for user "${badUser}"`
+    ],
+    [
+      "incorrectPass",
+      () =>
+        xchain.send(
+          user,
+          badPass,
+          "AVAX",
+          10,
+          addrB.value,
+          [addrC.value],
+          addrB.value,
+          memo
+        ),
+      (x) => x,
+      Matcher.toThrow,
+      () => `problem retrieving user: incorrect password for user "${user}"`
+    ],
+    [
+      "getBalance",
+      () => xchain.getBalance(whaleAddr, "AVAX"),
+      (x) => x.balance,
+      Matcher.toBe,
+      () => "300000000000000000"
+    ],
+    [
+      "getBalance2",
+      () => xchain.getBalance(whaleAddr, "AVAX"),
+      (x) => x.utxoIDs[0].txID,
+      Matcher.toBe,
+      () => "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe"
+    ],
+    [
+      "importKey",
+      () => xchain.importKey(user, passwd, key),
+      (x) => x,
+      Matcher.toBe,
+      () => whaleAddr
+    ],
+    [
+      "send",
+      () =>
+        xchain.send(
+          user,
+          passwd,
+          "AVAX",
+          10,
+          addrB.value,
+          [whaleAddr],
+          whaleAddr,
+          memo
+        ),
+      (x) => x.txID,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "sendMultiple",
+      () =>
+        xchain.sendMultiple(
+          user,
+          passwd,
+          [
+            { assetID: "AVAX", amount: 10, to: addrB.value },
+            { assetID: "AVAX", amount: 20, to: addrC.value }
+          ],
+          [whaleAddr],
+          whaleAddr,
+          memo
+        ),
+      (x) => x.txID,
+      Matcher.Get,
+      () => tx
+    ],
+    [
+      "listAddrs",
+      () => xchain.listAddresses(user, passwd),
+      (x) => x.sort(),
+      Matcher.toEqual,
+      () => [whaleAddr, addrB.value, addrC.value].sort()
+    ],
+    [
+      "exportKey",
+      () => xchain.exportKey(user, passwd, addrB.value),
+      (x) => x,
+      Matcher.toMatch,
+      () => /PrivateKey-\w*/
+    ],
+    [
+      "export",
+      () =>
+        xchain.export(
+          user,
+          passwd,
+          "C" + addrB.value.substring(1),
+          new BN(10),
+          "AVAX"
+        ),
+      (x) => x,
+      Matcher.toThrow,
+      () => "couldn't unmarshal an argument"
+    ],
+    [
+      "exportAVAX",
+      () =>
+        xchain.exportAVAX(
+          user,
+          passwd,
+          "C" + addrB.value.substring(1),
+          new BN(10)
+        ),
+      (x) => x,
+      Matcher.toThrow,
+      () => "couldn't unmarshal an argument"
+    ],
+    [
+      "import",
+      () => xchain.import(user, passwd, addrB.value, "C"),
+      (x) => x,
+      Matcher.toThrow,
+      () => "problem issuing transaction: no import inputs"
+    ],
+    [
+      "importAVAX",
+      () => xchain.importAVAX(user, passwd, addrB.value, "P"),
+      (x) => x,
+      Matcher.toThrow,
+      () => "problem issuing transaction: no import inputs"
+    ],
+    [
+      "createFixed",
+      () =>
+        xchain.createFixedCapAsset(user, passwd, "Some Coin", "SCC", 0, [
+          { address: whaleAddr, amount: "10000" }
+        ]),
+      (x) => x,
+      Matcher.Get,
+      () => asset
+    ],
+    [
+      "createVar",
+      () =>
+        xchain.createVariableCapAsset(user, passwd, "Some Coin", "SCC", 0, [
+          { minters: [whaleAddr], threshold: 1 }
+        ]),
+      (x) => x,
+      Matcher.Get,
+      () => asset
+    ],
+    [
+      "mint",
+      () =>
+        xchain.mint(user, passwd, 1500, asset.value, addrB.value, [whaleAddr]),
+      (x) => x,
+      Matcher.toThrow,
+      () => "couldn't unmarshal an argument"
+    ],
+    [
+      "getTx",
+      () => xchain.getTx(tx.value),
+      (x) => x,
+      Matcher.toMatch,
+      () => /\w+/
+    ],
+    [
+      "getTxStatus",
+      () => xchain.getTxStatus(tx.value),
+      (x) => x,
+      Matcher.toBe,
+      () => "Processing"
+    ],
+    [
+      "getAssetDesc",
+      () => xchain.getAssetDescription(asset.value),
+      (x) => [x.name, x.symbol],
+      Matcher.toEqual,
+      () => ["Some Coin", "SCC"]
+    ]
   ]
 
   createTests(tests_spec)
-
 })

--- a/e2e_tests/xchain_nomock.test.ts
+++ b/e2e_tests/xchain_nomock.test.ts
@@ -163,28 +163,8 @@ describe("XChain", (): void => {
       () => "couldn't unmarshal an argument"
     ],
     [
-      "exportAVAX",
-      () =>
-        xchain.exportAVAX(
-          user,
-          passwd,
-          "C" + addrB.value.substring(1),
-          new BN(10)
-        ),
-      (x) => x,
-      Matcher.toThrow,
-      () => "couldn't unmarshal an argument"
-    ],
-    [
       "import",
       () => xchain.import(user, passwd, addrB.value, "C"),
-      (x) => x,
-      Matcher.toThrow,
-      () => "problem issuing transaction: no import inputs"
-    ],
-    [
-      "importAVAX",
-      () => xchain.importAVAX(user, passwd, addrB.value, "P"),
       (x) => x,
       Matcher.toThrow,
       () => "problem issuing transaction: no import inputs"

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -36,7 +36,6 @@ import {
   CreateAddressParams,
   CreateFixedCapAssetParams,
   CreateVariableCapAssetParams,
-  ExportAVAXParams,
   ExportParams,
   ExportKeyParams,
   GetAllBalancesParams,
@@ -46,7 +45,6 @@ import {
   GetTxParams,
   GetTxStatusParams,
   GetUTXOsParams,
-  ImportAVAXParams,
   ImportParams,
   ImportKeyParams,
   ListAddressesParams,
@@ -579,7 +577,7 @@ export class AVMAPI extends JRPCAPI {
   /**
    * Send ANT (Avalanche Native Token) assets including AVAX from the X-Chain to an account on the P-Chain or C-Chain.
    *
-   * After calling this method, you must call the P-Chain's `importAVAX` or the C-Chain’s `import` method to complete the transfer.
+   * After calling this method, you must call the P-Chain's `import` or the C-Chain’s `import` method to complete the transfer.
    *
    * @param username The Keystore user that controls the P-Chain or C-Chain account specified in `to`
    * @param password The password of the Keystore user
@@ -637,36 +635,6 @@ export class AVMAPI extends JRPCAPI {
     }
     const response: RequestResponseData = await this.callMethod(
       "avm.import",
-      params
-    )
-    return response.data.result.txID
-  }
-
-  /**
-   * Finalize a transfer of AVAX from the P-Chain to the X-Chain.
-   *
-   * Before this method is called, you must call the P-Chain’s `exportAVAX` method to initiate the transfer.
-   * @param username The Keystore user that controls the address specified in `to`
-   * @param password The password of the Keystore user
-   * @param to The address the AVAX is sent to. This must be the same as the to argument in the corresponding call to the P-Chain’s exportAVAX, except that the prepended X- should be included in this argument
-   * @param sourceChain Chain the funds are coming from.
-   *
-   * @returns String representing the transaction id
-   */
-  importAVAX = async (
-    username: string,
-    password: string,
-    to: string,
-    sourceChain: string
-  ): Promise<string> => {
-    const params: ImportAVAXParams = {
-      to,
-      sourceChain,
-      username,
-      password
-    }
-    const response: RequestResponseData = await this.callMethod(
-      "avm.importAVAX",
       params
     )
     return response.data.result.txID

--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -611,37 +611,6 @@ export class AVMAPI extends JRPCAPI {
   }
 
   /**
-   * Send AVAX from the X-Chain to an account on the P-Chain or C-Chain.
-   *
-   * After calling this method, you must call the P-Chain’s or C-Chain's importAVAX method to complete the transfer.
-   *
-   * @param username The Keystore user that controls the P-Chain account specified in `to`
-   * @param password The password of the Keystore user
-   * @param to The account on the P-Chain or C-Chain to send the AVAX to.
-   * @param amount Amount of AVAX to export as a {@link https://github.com/indutny/bn.js/|BN}
-   *
-   * @returns String representing the transaction id
-   */
-  exportAVAX = async (
-    username: string,
-    password: string,
-    to: string,
-    amount: BN
-  ): Promise<string> => {
-    const params: ExportAVAXParams = {
-      to,
-      amount: amount,
-      username,
-      password
-    }
-    const response: RequestResponseData = await this.callMethod(
-      "avm.exportAVAX",
-      params
-    )
-    return response.data.result.txID
-  }
-
-  /**
    * Send ANT (Avalanche Native Token) assets including AVAX from an account on the P-Chain or C-Chain to an address on the X-Chain. This transaction
    * must be signed with the key of the account that the asset is sent from and which pays
    * the transaction fee.

--- a/src/apis/avm/interfaces.ts
+++ b/src/apis/avm/interfaces.ts
@@ -57,17 +57,7 @@ export interface ExportParams extends CredsInterface {
   assetID: string
 }
 
-export interface ExportAVAXParams extends CredsInterface {
-  to: string
-  amount: BN
-}
-
 export interface ImportParams extends CredsInterface {
-  to: string
-  sourceChain: string
-}
-
-export interface ImportAVAXParams extends CredsInterface {
   to: string
   sourceChain: string
 }

--- a/tests/apis/avm/api.test.ts
+++ b/tests/apis/avm/api.test.ts
@@ -492,33 +492,6 @@ describe("AVMAPI", (): void => {
     expect(response).toBe(txID)
   })
 
-  test("importAVAX", async (): Promise<void> => {
-    const to: string = "abcdef"
-    const username: string = "Robert"
-    const password: string = "Paulson"
-    const txID: string = "valid"
-    const result: Promise<string> = api.importAVAX(
-      username,
-      password,
-      to,
-      blockchainID
-    )
-    const payload: object = {
-      result: {
-        txID: txID
-      }
-    }
-    const responseObj: HttpResponse = {
-      data: payload
-    }
-
-    mockAxios.mockResponse(responseObj)
-    const response: string = await result
-
-    expect(mockAxios.request).toHaveBeenCalledTimes(1)
-    expect(response).toBe(txID)
-  })
-
   test("createAddress", async (): Promise<void> => {
     const alias: string = "randomalias"
 

--- a/tests/apis/avm/api.test.ts
+++ b/tests/apis/avm/api.test.ts
@@ -465,34 +465,6 @@ describe("AVMAPI", (): void => {
     expect(response).toBe(txID)
   })
 
-  test("exportAVAX", async (): Promise<void> => {
-    const amount: BN = new BN(100)
-    const to: string = "abcdef"
-    const username: string = "Robert"
-    const password: string = "Paulson"
-    const txID: string = "valid"
-    const result: Promise<string> = api.exportAVAX(
-      username,
-      password,
-      to,
-      amount
-    )
-    const payload: object = {
-      result: {
-        txID: txID
-      }
-    }
-    const responseObj: HttpResponse = {
-      data: payload
-    }
-
-    mockAxios.mockResponse(responseObj)
-    const response: string = await result
-
-    expect(mockAxios.request).toHaveBeenCalledTimes(1)
-    expect(response).toBe(txID)
-  })
-
   test("import", async (): Promise<void> => {
     const to: string = "abcdef"
     const username: string = "Robert"


### PR DESCRIPTION

https://github.com/ava-labs/avalanchego/releases/tag/v1.6.1

deprecates. `avm.exportAVAX` and `avm.importAVAX`