### PR TITLE
update unit tests

### DIFF
--- a/tests/apis/evm/api.test.ts
+++ b/tests/apis/evm/api.test.ts
@@ -363,7 +363,7 @@ describe("EVMAPI", (): void => {
     const payload: object = {
       result: {
         tx,
-        encoding: "cb58",
+        encoding: "hex",
         blockHeight: 8
       }
     }

--- a/tests/apis/index/api.test.ts
+++ b/tests/apis/index/api.test.ts
@@ -26,7 +26,7 @@ describe("Index", () => {
   })
 
   test("getLastAccepted", async () => {
-    const encoding: string = "cb58"
+    const encoding: string = "hex"
     const baseurl: string = "/ext/index/X/tx"
     const respobj = {
       id,
@@ -51,7 +51,7 @@ describe("Index", () => {
   })
 
   test("getContainerByIndex", async () => {
-    const encoding: string = "cb58"
+    const encoding: string = "hex"
     const baseurl: string = "/ext/index/X/tx"
     const respobj = {
       id,
@@ -80,7 +80,7 @@ describe("Index", () => {
   })
 
   test("getContainerByID", async () => {
-    const encoding: string = "cb58"
+    const encoding: string = "hex"
     const baseurl: string = "/ext/index/X/tx"
     const respobj = {
       id,

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -2524,7 +2524,7 @@ describe("PlatformVMAPI", (): void => {
     const txID: string = "7sik3Pr6r1FeLrvK1oWwECBS8iJ5VPuSh"
     const result: Promise<GetRewardUTXOsResponse> = api.getRewardUTXOs(txID)
     const payload: object = {
-      result: { numFetched: "0", utxos: [], encoding: "cb58" }
+      result: { numFetched: "0", utxos: [], encoding: "hex" }
     }
     const responseObj: HttpResponse = {
       data: payload


### PR DESCRIPTION
Defaulting to `hex` encoding instead of `cb58`

This PR will replace unit tests and relevant examples