### PR TITLE
fix: use relative path to persistanceoptions

### DIFF
--- a/src/apis/platformvm/interfaces.ts
+++ b/src/apis/platformvm/interfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import BN from "bn.js"
-import { PersistanceOptions } from "src/utils/persistenceoptions"
+import { PersistanceOptions } from "../../../src/utils/persistenceoptions"
 import { TransferableOutput } from "."
 import { UTXOSet } from "../platformvm/utxos"
 


### PR DESCRIPTION
```
$ node --version
v14.17.5

$ tsc --version
Version 4.6.2
```

When following along the tutorial in the project README I tried to compile the following script:

```
import { Avalanche, BinTools, BN, Buffer } from "avalanche"

const bintools = BinTools.getInstance()

const myNetworkID = 1
const avalanche = new Avalanche("localhost", 9650, "http", myNetworkID)
const xchain = avalanche.XChain()
```

and received the following error...

```
node_modules/avalanche/dist/apis/platformvm/interfaces.d.ts:7:36 - error TS2307: Cannot find module 'src/utils/persistenceoptions' or its corresponding type declarations.

7 import { PersistanceOptions } from "src/utils/persistenceoptions";
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/avalanche/dist/apis/socket/socket.d.ts:7:8 - error TS1259: Module '"/home/sim/src/avax-testing/node_modules/isomorphic-ws/index"' can only be default-imported using the 'esModuleInterop' flag
```

It appeared that most of the imports from `src/utils` in other files included relative paths, so this is updating `interfaces.ts` to the same