### PR TITLE
Add the ability to specify a base endpoint

### DIFF
--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -30,6 +30,7 @@ export default class AvalancheCore {
   protected ip: string
   protected host: string
   protected port: number
+  protected baseEndpoint: string
   protected url: string
   protected auth: string = undefined
   protected headers: { [k: string]: string } = {}
@@ -43,13 +44,16 @@ export default class AvalancheCore {
    * @param port The port to resolve to reach the Avalanche Client RPC APIs.
    * @param protocol The protocol string to use before a "://" in a request,
    * ex: "http", "https", etc. Defaults to http
+   * @param baseEndpoint the base endpoint to reach the Avalanche Client RPC APIs,
+   * ex: "/rpc". Defaults to "/"
    * The following special characters are removed from host and protocol
    * &#,@+()$~%'":*?{} also less than and greater than signs
    */
   setAddress = (
     host: string,
     port: number,
-    protocol: string = "http"
+    protocol: string = "http",
+    baseEndpoint: string = ""
   ): void => {
     host = host.replace(/[&#,@+()$~%'":*?<>{}]/g, "")
     protocol = protocol.replace(/[&#,@+()$~%'":*?<>{}]/g, "")
@@ -64,9 +68,20 @@ export default class AvalancheCore {
     this.host = host
     this.port = port
     this.protocol = protocol
+    this.baseEndpoint = baseEndpoint
     let url: string = `${protocol}://${host}`
     if (port != undefined && typeof port === "number" && port >= 0) {
       url = `${url}:${port}`
+    }
+    if (
+      baseEndpoint != undefined &&
+      typeof baseEndpoint == "string" &&
+      baseEndpoint.length > 0
+    ) {
+      if (baseEndpoint[0] != "/") {
+        baseEndpoint = `/${baseEndpoint}`
+      }
+      url = `${url}${baseEndpoint}`
     }
     this.url = url
   }
@@ -90,6 +105,11 @@ export default class AvalancheCore {
    * Returns the port for the Avalanche node.
    */
   getPort = (): number => this.port
+
+  /**
+   * Returns the base endpoint for the Avalanche node.
+   */
+  getBaseEndpoint = (): string => this.baseEndpoint
 
   /**
    * Returns the URL of the Avalanche node (ip + port)
@@ -280,7 +300,7 @@ export default class AvalancheCore {
       }
     } else {
       config = {
-        baseURL: `${this.protocol}://${this.host}:${this.port}`,
+        baseURL: this.url,
         responseType: "text",
         ...this.requestConfig
       }
@@ -450,7 +470,9 @@ export default class AvalancheCore {
    * @param port The port to resolve to reach the Avalanche Client APIs
    * @param protocol The protocol string to use before a "://" in a request, ex: "http", "https", "git", "ws", etc ...
    */
-  constructor(host: string, port: number, protocol: string = "http") {
-    this.setAddress(host, port, protocol)
+  constructor(host?: string, port?: number, protocol: string = "http") {
+    if (host != undefined) {
+      this.setAddress(host, port, protocol)
+    }
   }
 }

--- a/src/common/jrpcapi.ts
+++ b/src/common/jrpcapi.ts
@@ -39,11 +39,7 @@ export class JRPCAPI extends APIBase {
       headrs = { ...headrs, ...headers }
     }
 
-    baseURL = `${this.core.getProtocol()}://${this.core.getHost()}`
-    const port: number = this.core.getPort()
-    if (port != undefined && typeof port === "number" && port >= 0) {
-      baseURL = `${baseURL}:${port}`
-    }
+    baseURL = this.core.getURL()
 
     const axConf: AxiosRequestConfig = {
       baseURL: baseURL,

--- a/src/common/restapi.ts
+++ b/src/common/restapi.ts
@@ -32,7 +32,7 @@ export class RESTAPI extends APIBase {
 
   protected axConf = (): AxiosRequestConfig => {
     return {
-      baseURL: `${this.core.getProtocol()}://${this.core.getHost()}:${this.core.getPort()}`,
+      baseURL: this.core.getURL(),
       responseType: "json"
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,8 +103,8 @@ export default class Avalanche extends AvalancheCore {
    * @param skipinit Skips creating the APIs. Defaults to false
    */
   constructor(
-    host: string,
-    port: number,
+    host?: string,
+    port?: number,
     protocol: string = "http",
     networkID: number = DefaultNetworkID,
     XChainID: string = undefined,

--- a/tests/avalanche.test.ts
+++ b/tests/avalanche.test.ts
@@ -55,6 +55,17 @@ describe("Avalanche", (): void => {
     expect(avalancheCore.getProtocol()).toBe(encrypted)
     expect(avalancheCore.getURL()).toBe(url)
   })
+  test("Can specify base endpoint", (): void => {
+    avalanche = new Avalanche()
+    avalanche.setAddress(api, port, encrypted, "rpc")
+    avalanche.setNetworkID(networkID)
+    expect(avalanche.getHost()).toBe(api)
+    expect(avalanche.getProtocol()).toBe(encrypted)
+    expect(avalanche.getPort()).toBe(port)
+    expect(avalanche.getBaseEndpoint()).toBe("rpc")
+    expect(avalanche.getURL()).toBe(`${url}/rpc`)
+    expect(avalanche.getNetworkID()).toBe(networkID)
+  })
   test("Can initialize without port", (): void => {
     protocol = encrypted
     host = api


### PR DESCRIPTION
Based on [this PR](https://github.com/ava-labs/avalanchejs/pull/549)

This is for scenarios where the API has a non root base endpoint e.g. `https://someaddress.com/rpc`
today, you can do

```
const avalanche: Avalanche = new Avalanche("someaddress.com/rpc", undefined, "https")
```
and that will work if you don't need to specify a port. but if the node listens on a non standard port e.g.
```
const avalanche: Avalanche = new Avalanche("someaddress.com/rpc", 9650, "https")
```
it will try to append the port after `/rpc`, resulting in the URL `https://someaddress.com/rpc:9650` which is invalid.

This PR adds the ability to specify a base endpoint. 
I made the `baseEndpoint` argument available only when using `setAddress` in order to make it backwards compatible.

```
const avalanche: Avalanche = new Avalanche();
avalanche.setAddress("someaddress.com", 9650, "https", "rpc");
```