### PR TITLE
Refactor `SubnetAuth` for `CreateChainTx`

### DIFF
--- a/examples/avm/README.md
+++ b/examples/avm/README.md
@@ -3,6 +3,7 @@
 Example scripts for the [Avalanche Virtual Machine](https://docs.avax.network/build/references/avm-transaction-serialization)
 
 * [addressFromBuffer.ts](./addressFromBuffer.ts)
+* [baseEndpoint.ts](./baseEndpoint.ts)
 * [baseTx-ant.ts](./baseTx-ant.ts)
 * [baseTx-avax-create-multisig.ts](./baseTx-avax-create-multisig.ts)
 * [baseTx-avax-send-multisig.ts](./baseTx-avax-send-multisig.ts)

--- a/examples/avm/baseEndpoint.ts
+++ b/examples/avm/baseEndpoint.ts
@@ -1,0 +1,16 @@
+import { Avalanche } from "../../src"
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const baseEndpoint: string = "rpc"
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+avalanche.setAddress(ip, port, protocol, baseEndpoint)
+
+const main = async (): Promise<any> => {
+  const baseEndpoint: string = avalanche.getBaseEndpoint()
+  console.log(baseEndpoint)
+}
+
+main()

--- a/examples/avm/exportTx-avax-to-the-pchain-and-create-a-multisig-atomic-utxo.ts
+++ b/examples/avm/exportTx-avax-to-the-pchain-and-create-a-multisig-atomic-utxo.ts
@@ -1,0 +1,123 @@
+import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import {
+  AVMAPI,
+  KeyChain,
+  SECPTransferOutput,
+  SECPTransferInput,
+  TransferableOutput,
+  TransferableInput,
+  UTXOSet,
+  UTXO,
+  AmountOutput,
+  UnsignedTx,
+  Tx,
+  ExportTx
+} from "../../src/apis/avm"
+import {
+  PlatformVMAPI,
+  KeyChain as PlatformVMKeyChain
+} from "../../src/apis/platformvm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey,
+  Defaults
+} from "../../src/utils"
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const xchain: AVMAPI = avalanche.XChain()
+const pchain: PlatformVMAPI = avalanche.PChain()
+const bintools: BinTools = BinTools.getInstance()
+const xKeychain: KeyChain = xchain.keyChain()
+const pKeychain: PlatformVMKeyChain = pchain.keyChain()
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+xKeychain.importKey(privKey)
+pKeychain.importKey(privKey)
+
+privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// X-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+xKeychain.importKey(privKey)
+pKeychain.importKey(privKey)
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+xKeychain.importKey(privKey)
+pKeychain.importKey(privKey)
+const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
+const xAddressStrings: string[] = xchain.keyChain().getAddressStrings()
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
+const xChainID: string = Defaults.network[networkID].X.blockchainID
+const xChainIDBuf: Buffer = bintools.cb58Decode(xChainID)
+const avaxAssetID: string = Defaults.network[networkID].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
+const pChainID: string = Defaults.network[networkID].P.blockchainID
+const pChainIDBuf: Buffer = bintools.cb58Decode(pChainID)
+const exportedOuts: TransferableOutput[] = []
+const outputs: TransferableOutput[] = []
+const inputs: TransferableInput[] = []
+const fee: BN = xchain.getDefaultTxFee()
+const threshold: number = 2
+const locktime: BN = new BN(0)
+const memo: Buffer = Buffer.from(
+  "Export AVAX from the X-Chain to the P-Chain and create a multisig atomic utxo"
+)
+
+const main = async (): Promise<any> => {
+  const getBalanceResponse: any = await xchain.getBalance(
+    xAddressStrings[0],
+    avaxAssetID
+  )
+  const balance: BN = new BN(getBalanceResponse.balance)
+  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+    balance.sub(fee),
+    pAddresses,
+    locktime,
+    threshold
+  )
+  const transferableOutput: TransferableOutput = new TransferableOutput(
+    avaxAssetIDBuf,
+    secpTransferOutput
+  )
+  exportedOuts.push(transferableOutput)
+
+  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+  const utxoSet: UTXOSet = avmUTXOResponse.utxos
+  const utxos: UTXO[] = utxoSet.getAllUTXOs()
+  utxos.forEach((utxo: UTXO): void => {
+    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+    const amount: BN = amountOutput.getAmount().clone()
+    const txID: Buffer = utxo.getTxID()
+    const outputIdx: Buffer = utxo.getOutputIdx()
+
+    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amount)
+    secpTransferInput.addSignatureIdx(0, xAddresses[0])
+
+    const input: TransferableInput = new TransferableInput(
+      txID,
+      outputIdx,
+      avaxAssetIDBuf,
+      secpTransferInput
+    )
+    inputs.push(input)
+  })
+
+  const exportTx: ExportTx = new ExportTx(
+    networkID,
+    xChainIDBuf,
+    outputs,
+    inputs,
+    memo,
+    pChainIDBuf,
+    exportedOuts
+  )
+  const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
+  const tx: Tx = unsignedTx.sign(xKeychain)
+  const txid: string = await xchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/evm/exportTx-avax-pchain-create-multisig-atomic-output.ts
+++ b/examples/evm/exportTx-avax-pchain-create-multisig-atomic-output.ts
@@ -1,0 +1,108 @@
+import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import {
+  PlatformVMAPI,
+  KeyChain as PlatformVMKeyChain
+} from "../../src/apis/platformvm"
+import {
+  EVMAPI,
+  KeyChain as EVMKeyChain,
+  UnsignedTx,
+  Tx,
+  EVMInput,
+  ExportTx,
+  SECPTransferOutput,
+  TransferableOutput
+} from "../../src/apis/evm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey,
+  Defaults,
+  ONEAVAX
+} from "../../src/utils"
+const Web3 = require("web3")
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const pchain: PlatformVMAPI = avalanche.PChain()
+const cchain: EVMAPI = avalanche.CChain()
+const bintools: BinTools = BinTools.getInstance()
+const pKeychain: PlatformVMKeyChain = pchain.keyChain()
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+
+// let privKey: string = "PrivateKey-2PvNEohp3sNL41g4XcCBym5hpeT1szSTZXxL7VGS28eoGvq3k7"
+const cKeychain: EVMKeyChain = cchain.keyChain()
+cKeychain.importKey(privKey)
+
+privKey = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+// P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45
+pKeychain.importKey(privKey)
+
+// privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// X-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+pKeychain.importKey(privKey)
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
+const cAddresses: Buffer[] = cchain.keyChain().getAddresses()
+const pChainId: string = Defaults.network[networkID].P.blockchainID
+const pChainIdBuf: Buffer = bintools.cb58Decode(pChainId)
+const cChainId: string = Defaults.network[networkID].C.blockchainID
+const cChainIdBuf: Buffer = bintools.cb58Decode(cChainId)
+const avaxAssetID: string = Defaults.network[networkID].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
+const cHexAddress: string = "0xeA6B543A9E625C04745EcA3D7a74D74B733b8C15"
+const evmInputs: EVMInput[] = []
+const exportedOuts: TransferableOutput[] = []
+const path: string = "/ext/bc/C/rpc"
+const web3 = new Web3(`${protocol}://${ip}:${port}${path}`)
+const threshold: number = 2
+
+const main = async (): Promise<any> => {
+  let balance: BN = await web3.eth.getBalance(cHexAddress)
+  balance = new BN(balance.toString().substring(0, 17))
+  const fee: BN = cchain.getDefaultTxFee()
+  const txcount = await web3.eth.getTransactionCount(cHexAddress)
+  const nonce: number = txcount
+  const locktime: BN = new BN(0)
+
+  const evmInput: EVMInput = new EVMInput(
+    cHexAddress,
+    ONEAVAX,
+    avaxAssetID,
+    nonce
+  )
+  evmInput.addSignatureIdx(0, cAddresses[0])
+  evmInputs.push(evmInput)
+
+  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+    ONEAVAX.sub(fee.mul(new BN(2))),
+    pAddresses,
+    locktime,
+    threshold
+  )
+  const transferableOutput: TransferableOutput = new TransferableOutput(
+    avaxAssetIDBuf,
+    secpTransferOutput
+  )
+  exportedOuts.push(transferableOutput)
+
+  const exportTx: ExportTx = new ExportTx(
+    networkID,
+    cChainIdBuf,
+    pChainIdBuf,
+    evmInputs,
+    exportedOuts
+  )
+
+  const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
+  const tx: Tx = unsignedTx.sign(cKeychain)
+  const txid: string = await cchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/evm/importTx-avax-to-the-pchain-and-consume-a-multisig-output.ts
+++ b/examples/evm/importTx-avax-to-the-pchain-and-consume-a-multisig-output.ts
@@ -1,0 +1,96 @@
+import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import {
+  EVMAPI,
+  EVMOutput,
+  ImportTx,
+  TransferableInput,
+  KeyChain,
+  UTXO,
+  UTXOSet,
+  SECPTransferInput,
+  AmountOutput,
+  UnsignedTx,
+  Tx
+} from "../../src/apis/evm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey,
+  Defaults
+} from "../../src/utils"
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const cchain: EVMAPI = avalanche.CChain()
+const bintools: BinTools = BinTools.getInstance()
+const cKeychain: KeyChain = cchain.keyChain()
+const cHexAddress: string = "0xeA6B543A9E625C04745EcA3D7a74D74B733b8C15"
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+cKeychain.importKey(privKey)
+
+// let privKey: string = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+// P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45
+
+// privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// X-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+cKeychain.importKey(privKey)
+const cAddresses: Buffer[] = cchain.keyChain().getAddresses()
+const cAddressStrings: string[] = cchain.keyChain().getAddressStrings()
+const cChainId: string = Defaults.network[networkID].C.blockchainID
+const cChainIdBuf: Buffer = bintools.cb58Decode(cChainId)
+const pChainId: string = Defaults.network[networkID].P.blockchainID
+const pChainIdBuf: Buffer = bintools.cb58Decode(pChainId)
+const importedIns: TransferableInput[] = []
+const evmOutputs: EVMOutput[] = []
+const fee: BN = cchain.getDefaultTxFee()
+
+const main = async (): Promise<any> => {
+  const u: any = await cchain.getUTXOs(cAddressStrings, "P")
+  const utxoSet: UTXOSet = u.utxos
+  const utxos: UTXO[] = utxoSet.getAllUTXOs()
+  utxos.forEach((utxo: UTXO): void => {
+    const assetID: Buffer = utxo.getAssetID()
+    const txid: Buffer = utxo.getTxID()
+    const outputidx: Buffer = utxo.getOutputIdx()
+    const output: AmountOutput = utxo.getOutput() as AmountOutput
+    const amount: BN = output.getAmount()
+    const input: SECPTransferInput = new SECPTransferInput(amount)
+    input.addSignatureIdx(0, cAddresses[1])
+    input.addSignatureIdx(1, cAddresses[0])
+    const xferin: TransferableInput = new TransferableInput(
+      txid,
+      outputidx,
+      assetID,
+      input
+    )
+    importedIns.push(xferin)
+
+    const evmOutput: EVMOutput = new EVMOutput(
+      cHexAddress,
+      amount.sub(fee.mul(new BN(3))),
+      assetID
+    )
+    evmOutputs.push(evmOutput)
+  })
+
+  const importTx: ImportTx = new ImportTx(
+    networkID,
+    cChainIdBuf,
+    pChainIdBuf,
+    importedIns,
+    evmOutputs
+  )
+
+  const unsignedTx: UnsignedTx = new UnsignedTx(importTx)
+  const tx: Tx = unsignedTx.sign(cKeychain)
+  const txid: string = await cchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/platformvm/baseTx-avax-create-multisig.ts
+++ b/examples/platformvm/baseTx-avax-create-multisig.ts
@@ -10,101 +10,106 @@ import {
   UTXO,
   AmountOutput,
   UnsignedTx,
-  CreateSubnetTx,
   Tx,
-  SECPOwnerOutput
+  BaseTx
 } from "../../src/apis/platformvm"
+import { GetBalanceResponse } from "../../src/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
 } from "../../src/utils"
 
+const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"
 const port: number = 9650
 const protocol: string = "http"
 const networkID: number = 1337
+const xBlockchainID: string = Defaults.network[networkID].X.blockchainID
+const xBlockchainIDBuf: Buffer = bintools.cb58Decode(xBlockchainID)
+const avaxAssetID: string = Defaults.network[networkID].X.avaxAssetID
+const avaxAssetIDBuf: Buffer = bintools.cb58Decode(avaxAssetID)
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
-const bintools: BinTools = BinTools.getInstance()
 const pKeychain: KeyChain = pchain.keyChain()
 let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
-// 'P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p'
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
 pKeychain.importKey(privKey)
 
 privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
-// 'P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj'
+// X-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
 pKeychain.importKey(privKey)
 
-privKey = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
-// 'P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45'
+privKey = "PrivateKey-24b2s6EqkBp9bFG5S3Xxi4bjdxFqeRk56ck7QdQArVbwKkAvxz"
+// X-custom1aekly2mwnsz6lswd6u0jqvd9u6yddt5884pyuc
 pKeychain.importKey(privKey)
-const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
-const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
-const pChainBlockchainID: string = Defaults.network[networkID].P.blockchainID
+const xAddresses: Buffer[] = pchain.keyChain().getAddresses()
+const xAddressStrings: string[] = pchain.keyChain().getAddressStrings()
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
-const fee: BN = pchain.getCreateSubnetTxFee()
-const threshold: number = 1
-const threshold2: number = 2
+const fee: BN = pchain.getDefaultTxFee()
+const threshold: number = 3
 const locktime: BN = new BN(0)
-const memo: Buffer = Buffer.from("Manually create a subnet")
+const memo: Buffer = Buffer.from(
+  "AVM manual create multisig BaseTx to send AVAX"
+)
+// Uncomment for codecID 00 01
+// const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
-  const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
-  const unlocked: BN = new BN(getBalanceResponse.unlocked)
+  const getBalanceResponse: GetBalanceResponse = await pchain.getBalance(
+    xAddressStrings[0]
+  )
+  const balance: BN = new BN(getBalanceResponse.balance)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    unlocked.sub(fee),
-    [pAddresses[0]],
+    balance.sub(fee),
+    xAddresses,
     locktime,
     threshold
   )
+  // Uncomment for codecID 00 01
+  //   secpTransferOutput.setCodecID(codecID)
   const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetID,
+    avaxAssetIDBuf,
     secpTransferOutput
   )
   outputs.push(transferableOutput)
 
-  const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
-  const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
+  const avmUTXOResponse: any = await pchain.getUTXOs(xAddressStrings)
+  const utxoSet: UTXOSet = avmUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
   utxos.forEach((utxo: UTXO): void => {
-    const amountOutput = utxo.getOutput() as AmountOutput
+    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
     const amt: BN = amountOutput.getAmount().clone()
     const txid: Buffer = utxo.getTxID()
     const outputidx: Buffer = utxo.getOutputIdx()
 
     const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    secpTransferInput.addSignatureIdx(0, pAddresses[0])
+    // Uncomment for codecID 00 01
+    // secpTransferInput.setCodecID(codecID)
+    secpTransferInput.addSignatureIdx(0, xAddresses[0])
 
     const input: TransferableInput = new TransferableInput(
       txid,
       outputidx,
-      avaxAssetID,
+      avaxAssetIDBuf,
       secpTransferInput
     )
     inputs.push(input)
   })
 
-  const subnetOwner: SECPOwnerOutput = new SECPOwnerOutput(
-    pAddresses,
-    locktime,
-    threshold2
-  )
-  const createSubnetTx: CreateSubnetTx = new CreateSubnetTx(
+  const baseTx: BaseTx = new BaseTx(
     networkID,
-    bintools.cb58Decode(pChainBlockchainID),
+    xBlockchainIDBuf,
     outputs,
     inputs,
-    memo,
-    subnetOwner
+    memo
   )
-
-  const unsignedTx: UnsignedTx = new UnsignedTx(createSubnetTx)
+  // Uncomment for codecID 00 01
+  // baseTx.setCodecID(codecID)
+  const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
   const tx: Tx = unsignedTx.sign(pKeychain)
   const txid: string = await pchain.issueTx(tx)
   console.log(`Success! TXID: ${txid}`)
 }
-
 main()

--- a/examples/platformvm/createChainTx.ts
+++ b/examples/platformvm/createChainTx.ts
@@ -19,8 +19,7 @@ import {
   AmountOutput,
   UnsignedTx,
   CreateChainTx,
-  Tx,
-  SubnetAuth
+  Tx
 } from "../../src/apis/platformvm"
 import { Output } from "../../src/common"
 import {
@@ -40,7 +39,11 @@ const networkID: number = 1337
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
 const pKeychain: KeyChain = pchain.keyChain()
-const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+pKeychain.importKey(privKey)
+privKey = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+pKeychain.importKey(privKey)
+privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
 pKeychain.importKey(privKey)
 const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
@@ -120,15 +123,12 @@ const main = async (): Promise<any> => {
   })
 
   const subnetID: Buffer = bintools.cb58Decode(
-    "WYziRrZeZVftQ56QizLxmSfwofLyJM8u3uYbRHA1Yc7YtMmbN"
+    "2giH3n6ZEVuomNypEVPqEUn2kPJxbCAJerh1PuM7LsFqExheXY"
   )
   const chainName: string = "EPIC AVM"
   const vmID: string = "avm"
   const fxIDs: string[] = ["secp256k1fx", "nftfx", "propertyfx"]
   fxIDs.sort()
-  const addressIndex: Buffer = Buffer.alloc(4)
-  addressIndex.writeUIntBE(0x0, 0, 4)
-  const subnetAuth: SubnetAuth = new SubnetAuth([addressIndex])
   const blockchainID: Buffer = bintools.cb58Decode(pChainBlockchainID)
   const createChainTx: CreateChainTx = new CreateChainTx(
     networkID,
@@ -140,9 +140,11 @@ const main = async (): Promise<any> => {
     chainName,
     vmID,
     fxIDs,
-    genesisData,
-    subnetAuth
+    genesisData
   )
+
+  createChainTx.addSignatureIdx(0, pAddresses[0])
+  createChainTx.addSignatureIdx(1, pAddresses[1])
   const unsignedTx: UnsignedTx = new UnsignedTx(createChainTx)
   const tx: Tx = unsignedTx.sign(pKeychain)
   const txid: string = await pchain.issueTx(tx)

--- a/examples/platformvm/createChainTx.ts
+++ b/examples/platformvm/createChainTx.ts
@@ -40,10 +40,15 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
 const pKeychain: KeyChain = pchain.keyChain()
 let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// 'P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p',
 pKeychain.importKey(privKey)
-privKey = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
-pKeychain.importKey(privKey)
+
 privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// 'P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj'
+pKeychain.importKey(privKey)
+
+privKey = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+// 'P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45',
 pKeychain.importKey(privKey)
 const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
@@ -123,7 +128,7 @@ const main = async (): Promise<any> => {
   })
 
   const subnetID: Buffer = bintools.cb58Decode(
-    "2giH3n6ZEVuomNypEVPqEUn2kPJxbCAJerh1PuM7LsFqExheXY"
+    "2aChGx4MubmgrpRqaNjcsN1JnBZ98bUmushPmyP5s1sc1dJz3n"
   )
   const chainName: string = "EPIC AVM"
   const vmID: string = "avm"

--- a/examples/platformvm/createSubnetTx.ts
+++ b/examples/platformvm/createSubnetTx.ts
@@ -28,7 +28,9 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const pchain: PlatformVMAPI = avalanche.PChain()
 const bintools: BinTools = BinTools.getInstance()
 const pKeychain: KeyChain = pchain.keyChain()
-const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+pKeychain.importKey(privKey)
+privKey = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
 pKeychain.importKey(privKey)
 const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
@@ -37,6 +39,7 @@ const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = pchain.getCreateSubnetTxFee()
 const threshold: number = 1
+const threshold2: number = 2
 const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from("Manually create a subnet")
 
@@ -46,7 +49,7 @@ const main = async (): Promise<any> => {
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
-    pAddresses,
+    [pAddresses[0]],
     locktime,
     threshold
   )
@@ -80,7 +83,7 @@ const main = async (): Promise<any> => {
   const subnetOwner: SECPOwnerOutput = new SECPOwnerOutput(
     pAddresses,
     locktime,
-    threshold
+    threshold2
   )
   const createSubnetTx: CreateSubnetTx = new CreateSubnetTx(
     networkID,

--- a/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
+++ b/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
@@ -1,5 +1,5 @@
 import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { EVMAPI, KeyChain as EVMKeyChain } from "../../src/apis/evm"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -14,7 +14,6 @@ import {
   Tx,
   ExportTx
 } from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
@@ -27,34 +26,50 @@ const port: number = 9650
 const protocol: string = "http"
 const networkID: number = 1337
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
-const xchain: AVMAPI = avalanche.XChain()
+const cchain: EVMAPI = avalanche.CChain()
 const pchain: PlatformVMAPI = avalanche.PChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const cKeychain: EVMKeyChain = cchain.keyChain()
 const pKeychain: KeyChain = pchain.keyChain()
-const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
-xKeychain.importKey(privKey)
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+cKeychain.importKey(privKey)
 pKeychain.importKey(privKey)
-const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
+
+// let privKey: string = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+// P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45
+
+// privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+cKeychain.importKey(privKey)
+pKeychain.importKey(privKey)
+const cAddresses: Buffer[] = cchain.keyChain().getAddresses()
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
-const xChainBlockchainID: string = Defaults.network[networkID].X.blockchainID
-const pChainBlockchainID: string = Defaults.network[networkID].P.blockchainID
+const cChainID: string = Defaults.network[networkID].C.blockchainID
+const cChainIDBuf: Buffer = bintools.cb58Decode(cChainID)
+const pChainID: string = Defaults.network[networkID].P.blockchainID
+const pChainIDBuf: Buffer = bintools.cb58Decode(pChainID)
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = MILLIAVAX
-const threshold: number = 1
+const threshold: number = 2
 const locktime: BN = new BN(0)
-const memo: Buffer = Buffer.from("Manually Export AVAX from P-Chain to X-Chain")
+const memo: Buffer = Buffer.from(
+  "Export AVAX from P-Chain to C-Chain and consume a multisig output and create a multisig atomic output"
+)
 
 const main = async (): Promise<any> => {
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
   const getBalanceResponse: any = await pchain.getBalance(pAddressStrings[0])
   const unlocked: BN = new BN(getBalanceResponse.unlocked)
-  console.log(unlocked.sub(fee).toString())
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
-    xAddresses,
+    cAddresses,
     locktime,
     threshold
   )
@@ -67,16 +82,17 @@ const main = async (): Promise<any> => {
   const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
-    const output: Output = utxo.getOutput()
-    // if (output.getOutputID() === 7) {
+  utxos.forEach((utxo: UTXO): void => {
     const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
+    const amt: BN = amountOutput.getAmount()
     const txid: Buffer = utxo.getTxID()
     const outputidx: Buffer = utxo.getOutputIdx()
 
     const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
+    secpTransferInput.addSignatureIdx(0, pAddresses[1])
+    if (utxo.getOutput().getThreshold() === 2) {
+      secpTransferInput.addSignatureIdx(1, pAddresses[0])
+    }
 
     const input: TransferableInput = new TransferableInput(
       txid,
@@ -85,16 +101,15 @@ const main = async (): Promise<any> => {
       secpTransferInput
     )
     inputs.push(input)
-    // }
   })
 
   const exportTx: ExportTx = new ExportTx(
     networkID,
-    bintools.cb58Decode(pChainBlockchainID),
+    pChainIDBuf,
     outputs,
     inputs,
     memo,
-    bintools.cb58Decode(xChainBlockchainID),
+    cChainIDBuf,
     exportedOuts
   )
 

--- a/examples/platformvm/exportTx-cchain.ts
+++ b/examples/platformvm/exportTx-cchain.ts
@@ -1,5 +1,5 @@
 import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { EVMAPI, KeyChain as EVMKeyChain } from "../../src/apis/evm"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -14,7 +14,6 @@ import {
   Tx,
   ExportTx
 } from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
@@ -27,25 +26,32 @@ const port: number = 9650
 const protocol: string = "http"
 const networkID: number = 1337
 const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
-const xchain: AVMAPI = avalanche.XChain()
+const cchain: EVMAPI = avalanche.CChain()
 const pchain: PlatformVMAPI = avalanche.PChain()
 const bintools: BinTools = BinTools.getInstance()
-const xKeychain: AVMKeyChain = xchain.keyChain()
+const cKeychain: EVMKeyChain = cchain.keyChain()
 const pKeychain: KeyChain = pchain.keyChain()
-const privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
-xKeychain.importKey(privKey)
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+cKeychain.importKey(privKey)
 pKeychain.importKey(privKey)
-const xAddresses: Buffer[] = xchain.keyChain().getAddresses()
+
+privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+cKeychain.importKey(privKey)
+pKeychain.importKey(privKey)
+const cAddresses: Buffer[] = cchain.keyChain().getAddresses()
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
 const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
-const xChainBlockchainID: string = Defaults.network[networkID].X.blockchainID
+const cChainBlockchainID: string = Defaults.network[networkID].C.blockchainID
 const pChainBlockchainID: string = Defaults.network[networkID].P.blockchainID
 const exportedOuts: TransferableOutput[] = []
 const outputs: TransferableOutput[] = []
 const inputs: TransferableInput[] = []
 const fee: BN = MILLIAVAX
-const threshold: number = 1
+const threshold: number = 2
 const locktime: BN = new BN(0)
-const memo: Buffer = Buffer.from("Manually Export AVAX from P-Chain to X-Chain")
+const memo: Buffer = Buffer.from("Manually Export AVAX from P-Chain to C-Chain")
 
 const main = async (): Promise<any> => {
   const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
@@ -54,7 +60,7 @@ const main = async (): Promise<any> => {
   console.log(unlocked.sub(fee).toString())
   const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
     unlocked.sub(fee),
-    xAddresses,
+    cAddresses,
     locktime,
     threshold
   )
@@ -67,16 +73,17 @@ const main = async (): Promise<any> => {
   const platformVMUTXOResponse: any = await pchain.getUTXOs(pAddressStrings)
   const utxoSet: UTXOSet = platformVMUTXOResponse.utxos
   const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
-    const output: Output = utxo.getOutput()
-    // if (output.getOutputID() === 7) {
+  utxos.forEach((utxo: UTXO): void => {
     const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
     const amt: BN = amountOutput.getAmount().clone()
     const txid: Buffer = utxo.getTxID()
     const outputidx: Buffer = utxo.getOutputIdx()
 
     const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
+    secpTransferInput.addSignatureIdx(0, pAddresses[0])
+    if (utxo.getOutput().getThreshold() === 2) {
+      secpTransferInput.addSignatureIdx(1, pAddresses[1])
+    }
 
     const input: TransferableInput = new TransferableInput(
       txid,
@@ -85,7 +92,6 @@ const main = async (): Promise<any> => {
       secpTransferInput
     )
     inputs.push(input)
-    // }
   })
 
   const exportTx: ExportTx = new ExportTx(
@@ -94,7 +100,7 @@ const main = async (): Promise<any> => {
     outputs,
     inputs,
     memo,
-    bintools.cb58Decode(xChainBlockchainID),
+    bintools.cb58Decode(cChainBlockchainID),
     exportedOuts
   )
 

--- a/examples/platformvm/importTx-avax-cchain-create-multisig.ts
+++ b/examples/platformvm/importTx-avax-cchain-create-multisig.ts
@@ -1,0 +1,117 @@
+import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  SECPTransferOutput,
+  SECPTransferInput,
+  TransferableOutput,
+  TransferableInput,
+  UTXOSet,
+  UTXO,
+  AmountOutput,
+  UnsignedTx,
+  Tx,
+  ImportTx
+} from "../../src/apis/platformvm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey,
+  Defaults
+} from "../../src/utils"
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const pchain: PlatformVMAPI = avalanche.PChain()
+const bintools: BinTools = BinTools.getInstance()
+const pKeychain: KeyChain = pchain.keyChain()
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+pKeychain.importKey(privKey)
+
+// let privKey: string = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+// P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45
+
+// privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+pKeychain.importKey(privKey)
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
+const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
+const cChainID: string = Defaults.network[networkID].C.blockchainID
+const cChainIDBuf: Buffer = bintools.cb58Decode(cChainID)
+const pChainID: string = Defaults.network[networkID].P.blockchainID
+const pChainIDBuf: Buffer = bintools.cb58Decode(pChainID)
+const importedInputs: TransferableInput[] = []
+const outputs: TransferableOutput[] = []
+const inputs: TransferableInput[] = []
+const fee: BN = pchain.getDefaultTxFee()
+const threshold: number = 2
+const locktime: BN = new BN(0)
+const memo: Buffer = Buffer.from(
+  "Import AVAX to the P-Chain from the C-Chain and consume a multisig atomic output and a create multisig output"
+)
+
+const main = async (): Promise<any> => {
+  const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
+  const platformvmUTXOResponse: any = await pchain.getUTXOs(
+    pAddressStrings,
+    cChainID
+  )
+  const utxoSet: UTXOSet = platformvmUTXOResponse.utxos
+  const utxos: UTXO[] = utxoSet.getAllUTXOs()
+  let amount: BN = new BN(0)
+  utxos.forEach((utxo: UTXO): void => {
+    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+    const amt: BN = amountOutput.getAmount()
+    const txid: Buffer = utxo.getTxID()
+    const outputidx: Buffer = utxo.getOutputIdx()
+    const assetID: Buffer = utxo.getAssetID()
+
+    if (avaxAssetID.toString("hex") === assetID.toString("hex")) {
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      secpTransferInput.addSignatureIdx(0, pAddresses[1])
+      secpTransferInput.addSignatureIdx(1, pAddresses[0])
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetID,
+        secpTransferInput
+      )
+      importedInputs.push(input)
+      amount = amount.add(amt)
+    }
+  })
+  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+    amount.sub(fee),
+    pAddresses,
+    locktime,
+    threshold
+  )
+  const transferableOutput: TransferableOutput = new TransferableOutput(
+    avaxAssetID,
+    secpTransferOutput
+  )
+  outputs.push(transferableOutput)
+
+  const importTx: ImportTx = new ImportTx(
+    networkID,
+    pChainIDBuf,
+    outputs,
+    inputs,
+    memo,
+    cChainIDBuf,
+    importedInputs
+  )
+
+  const unsignedTx: UnsignedTx = new UnsignedTx(importTx)
+  const tx: Tx = unsignedTx.sign(pKeychain)
+  const txid: string = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/platformvm/importTx-avax-from-the-xchain-and-create-a-multisig-utxo.ts
+++ b/examples/platformvm/importTx-avax-from-the-xchain-and-create-a-multisig-utxo.ts
@@ -1,0 +1,116 @@
+import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  SECPTransferOutput,
+  SECPTransferInput,
+  TransferableOutput,
+  TransferableInput,
+  UTXOSet,
+  UTXO,
+  AmountOutput,
+  UnsignedTx,
+  Tx,
+  ImportTx
+} from "../../src/apis/platformvm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey,
+  Defaults
+} from "../../src/utils"
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const pchain: PlatformVMAPI = avalanche.PChain()
+const bintools: BinTools = BinTools.getInstance()
+const pKeychain: KeyChain = pchain.keyChain()
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+pKeychain.importKey(privKey)
+
+privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+pKeychain.importKey(privKey)
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+pKeychain.importKey(privKey)
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
+const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
+const xChainID: string = Defaults.network[networkID].X.blockchainID
+const xChainIDBuf: Buffer = bintools.cb58Decode(xChainID)
+const pChainID: string = Defaults.network[networkID].P.blockchainID
+const pChainIDBuf: Buffer = bintools.cb58Decode(pChainID)
+const importedInputs: TransferableInput[] = []
+const outputs: TransferableOutput[] = []
+const inputs: TransferableInput[] = []
+const fee: BN = pchain.getDefaultTxFee()
+const threshold: number = 2
+const locktime: BN = new BN(0)
+const memo: Buffer = Buffer.from(
+  "Import AVAX to P-Chain from X-Chain and consume a multisig atomic output and create a multisig utxo"
+)
+
+const main = async (): Promise<any> => {
+  const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
+  const platformvmUTXOResponse: any = await pchain.getUTXOs(
+    pAddressStrings,
+    xChainID
+  )
+  const utxoSet: UTXOSet = platformvmUTXOResponse.utxos
+  const utxos: UTXO[] = utxoSet.getAllUTXOs()
+  let amount: BN = new BN(0)
+  utxos.forEach((utxo: UTXO): void => {
+    console.log(utxo.getOutput().getAddresses())
+    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+    const amt: BN = amountOutput.getAmount()
+    const txid: Buffer = utxo.getTxID()
+    const outputidx: Buffer = utxo.getOutputIdx()
+    const assetID: Buffer = utxo.getAssetID()
+
+    if (avaxAssetID.toString("hex") === assetID.toString("hex")) {
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      secpTransferInput.addSignatureIdx(1, pAddresses[2])
+      secpTransferInput.addSignatureIdx(2, pAddresses[1])
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetID,
+        secpTransferInput
+      )
+      importedInputs.push(input)
+      amount = amount.add(amt)
+    }
+  })
+  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+    amount.sub(fee),
+    pAddresses,
+    locktime,
+    threshold
+  )
+  const transferableOutput: TransferableOutput = new TransferableOutput(
+    avaxAssetID,
+    secpTransferOutput
+  )
+  outputs.push(transferableOutput)
+
+  const importTx: ImportTx = new ImportTx(
+    networkID,
+    pChainIDBuf,
+    outputs,
+    inputs,
+    memo,
+    xChainIDBuf,
+    importedInputs
+  )
+
+  const unsignedTx: UnsignedTx = new UnsignedTx(importTx)
+  const tx: Tx = unsignedTx.sign(pKeychain)
+  const txid: string = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/examples/platformvm/importTx-avax-to-the-P-Chain-from-the-C-Chain-and-consume-a-multisig-atomic-output-and-a-create-multisig-output.ts
+++ b/examples/platformvm/importTx-avax-to-the-P-Chain-from-the-C-Chain-and-consume-a-multisig-atomic-output-and-a-create-multisig-output.ts
@@ -1,0 +1,117 @@
+import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  SECPTransferOutput,
+  SECPTransferInput,
+  TransferableOutput,
+  TransferableInput,
+  UTXOSet,
+  UTXO,
+  AmountOutput,
+  UnsignedTx,
+  Tx,
+  ImportTx
+} from "../../src/apis/platformvm"
+import {
+  PrivateKeyPrefix,
+  DefaultLocalGenesisPrivateKey,
+  Defaults
+} from "../../src/utils"
+
+const ip: string = "localhost"
+const port: number = 9650
+const protocol: string = "http"
+const networkID: number = 1337
+const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+const pchain: PlatformVMAPI = avalanche.PChain()
+const bintools: BinTools = BinTools.getInstance()
+const pKeychain: KeyChain = pchain.keyChain()
+let privKey: string = `${PrivateKeyPrefix}${DefaultLocalGenesisPrivateKey}`
+// X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p
+pKeychain.importKey(privKey)
+
+// let privKey: string = "PrivateKey-24gdABgapjnsJfnYkfev6YPyQhTaCU72T9bavtDNTYivBLp2eW"
+// P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45
+
+// privKey = "PrivateKey-R6e8f5QSa89DjpvL9asNdhdJ4u8VqzMJStPV8VVdDmLgPd8a4"
+// P-custom15s7p7mkdev0uajrd0pzxh88kr8ryccztnlmzvj
+
+privKey = "PrivateKey-rKsiN3X4NSJcPpWxMSh7WcuY653NGQ7tfADgQwDZ9yyUPPDG9"
+// P-custom1jwwk62ktygl0w29rsq2hq55amamhpvx82kfnte
+pKeychain.importKey(privKey)
+const pAddresses: Buffer[] = pchain.keyChain().getAddresses()
+const pAddressStrings: string[] = pchain.keyChain().getAddressStrings()
+const cChainID: string = Defaults.network[networkID].C.blockchainID
+const cChainIDBuf: Buffer = bintools.cb58Decode(cChainID)
+const pChainID: string = Defaults.network[networkID].P.blockchainID
+const pChainIDBuf: Buffer = bintools.cb58Decode(pChainID)
+const importedInputs: TransferableInput[] = []
+const outputs: TransferableOutput[] = []
+const inputs: TransferableInput[] = []
+const fee: BN = pchain.getDefaultTxFee()
+const threshold: number = 2
+const locktime: BN = new BN(0)
+const memo: Buffer = Buffer.from(
+  "Import AVAX to the P-Chain from the C-Chain and consume a multisig atomic output and a create multisig output"
+)
+
+const main = async (): Promise<any> => {
+  const avaxAssetID: Buffer = await pchain.getAVAXAssetID()
+  const platformvmUTXOResponse: any = await pchain.getUTXOs(
+    pAddressStrings,
+    cChainID
+  )
+  const utxoSet: UTXOSet = platformvmUTXOResponse.utxos
+  const utxos: UTXO[] = utxoSet.getAllUTXOs()
+  let amount: BN = new BN(0)
+  utxos.forEach((utxo: UTXO): void => {
+    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+    const amt: BN = amountOutput.getAmount()
+    const txid: Buffer = utxo.getTxID()
+    const outputidx: Buffer = utxo.getOutputIdx()
+    const assetID: Buffer = utxo.getAssetID()
+
+    if (avaxAssetID.toString("hex") === assetID.toString("hex")) {
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      secpTransferInput.addSignatureIdx(0, pAddresses[1])
+      secpTransferInput.addSignatureIdx(1, pAddresses[0])
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetID,
+        secpTransferInput
+      )
+      importedInputs.push(input)
+      amount = amount.add(amt)
+    }
+  })
+  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+    amount.sub(fee),
+    pAddresses,
+    locktime,
+    threshold
+  )
+  const transferableOutput: TransferableOutput = new TransferableOutput(
+    avaxAssetID,
+    secpTransferOutput
+  )
+  outputs.push(transferableOutput)
+
+  const importTx: ImportTx = new ImportTx(
+    networkID,
+    pChainIDBuf,
+    outputs,
+    inputs,
+    memo,
+    cChainIDBuf,
+    importedInputs
+  )
+
+  const unsignedTx: UnsignedTx = new UnsignedTx(importTx)
+  const tx: Tx = unsignedTx.sign(pKeychain)
+  const txid: string = await pchain.issueTx(tx)
+  console.log(`Success! TXID: ${txid}`)
+}
+
+main()

--- a/src/apis/avm/basetx.ts
+++ b/src/apis/avm/basetx.ts
@@ -155,7 +155,7 @@ export class BaseTx extends StandardBaseTx<KeyPair, KeyChain> {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = []
+    const creds: Credential[] = []
     for (let i: number = 0; i < this.ins.length; i++) {
       const cred: Credential = SelectCredentialClass(
         this.ins[`${i}`].getInput().getCredentialID()
@@ -168,9 +168,9 @@ export class BaseTx extends StandardBaseTx<KeyPair, KeyChain> {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       }
-      sigs.push(cred)
+      creds.push(cred)
     }
-    return sigs
+    return creds
   }
 
   clone(): this {

--- a/src/apis/avm/importtx.ts
+++ b/src/apis/avm/importtx.ts
@@ -175,7 +175,7 @@ export class ImportTx extends BaseTx {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = super.sign(msg, kc)
+    const creds: Credential[] = super.sign(msg, kc)
     for (let i: number = 0; i < this.importIns.length; i++) {
       const cred: Credential = SelectCredentialClass(
         this.importIns[`${i}`].getInput().getCredentialID()
@@ -188,9 +188,9 @@ export class ImportTx extends BaseTx {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       }
-      sigs.push(cred)
+      creds.push(cred)
     }
-    return sigs
+    return creds
   }
 
   /**

--- a/src/apis/avm/operationtx.ts
+++ b/src/apis/avm/operationtx.ts
@@ -125,7 +125,7 @@ export class OperationTx extends BaseTx {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = super.sign(msg, kc)
+    const creds: Credential[] = super.sign(msg, kc)
     for (let i: number = 0; i < this.ops.length; i++) {
       const cred: Credential = SelectCredentialClass(
         this.ops[`${i}`].getOperation().getCredentialID()
@@ -138,9 +138,9 @@ export class OperationTx extends BaseTx {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       }
-      sigs.push(cred)
+      creds.push(cred)
     }
-    return sigs
+    return creds
   }
 
   clone(): this {

--- a/src/apis/avm/tx.ts
+++ b/src/apis/avm/tx.ts
@@ -85,8 +85,8 @@ export class UnsignedTx extends StandardUnsignedTx<KeyPair, KeyChain, BaseTx> {
     const msg: Buffer = Buffer.from(
       createHash("sha256").update(txbuff).digest()
     )
-    const sigs: Credential[] = this.transaction.sign(msg, kc)
-    return new Tx(this, sigs)
+    const creds: Credential[] = this.transaction.sign(msg, kc)
+    return new Tx(this, creds)
   }
 }
 

--- a/src/apis/evm/basetx.ts
+++ b/src/apis/evm/basetx.ts
@@ -63,8 +63,8 @@ export class EVMBaseTx extends EVMStandardBaseTx<KeyPair, KeyChain> {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = []
-    return sigs
+    const creds: Credential[] = []
+    return creds
   }
 
   clone(): this {

--- a/src/apis/evm/exporttx.ts
+++ b/src/apis/evm/exporttx.ts
@@ -162,7 +162,7 @@ export class ExportTx extends EVMBaseTx {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = super.sign(msg, kc)
+    const creds: Credential[] = super.sign(msg, kc)
     this.inputs.forEach((input: EVMInput) => {
       const cred: Credential = SelectCredentialClass(input.getCredentialID())
       const sigidxs: SigIdx[] = input.getSigIdxs()
@@ -173,9 +173,9 @@ export class ExportTx extends EVMBaseTx {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       })
-      sigs.push(cred)
+      creds.push(cred)
     })
-    return sigs
+    return creds
   }
 
   /**

--- a/src/apis/evm/importtx.ts
+++ b/src/apis/evm/importtx.ts
@@ -182,7 +182,7 @@ export class ImportTx extends EVMBaseTx {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = super.sign(msg, kc)
+    const creds: Credential[] = super.sign(msg, kc)
     this.importIns.forEach((importIn: TransferableInput) => {
       const cred: Credential = SelectCredentialClass(
         importIn.getInput().getCredentialID()
@@ -195,9 +195,9 @@ export class ImportTx extends EVMBaseTx {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       })
-      sigs.push(cred)
+      creds.push(cred)
     })
-    return sigs
+    return creds
   }
 
   /**

--- a/src/apis/evm/tx.ts
+++ b/src/apis/evm/tx.ts
@@ -82,8 +82,8 @@ export class UnsignedTx extends EVMStandardUnsignedTx<
     const msg: Buffer = Buffer.from(
       createHash("sha256").update(txbuff).digest()
     )
-    const sigs: Credential[] = this.transaction.sign(msg, kc)
-    return new Tx(this, sigs)
+    const creds: Credential[] = this.transaction.sign(msg, kc)
+    return new Tx(this, creds)
   }
 }
 

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -1868,7 +1868,6 @@ export class PlatformVMAPI extends JRPCAPI {
    * @param vmID Optional ID of the VM running on the new chain
    * @param fxIDs Optional IDs of the feature extensions running on the new chain
    * @param genesisData Optional Byte representation of genesis state of the new chain
-   * @param subnetAuth Optional Specifies the addresses whose signatures will be provided to demonstrate that the owners of a subnet approve something
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
    * @param asOf Optional. The timestamp to verify the transaction against as a {@link https://github.com/indutny/bn.js/|BN}
    *
@@ -1883,7 +1882,6 @@ export class PlatformVMAPI extends JRPCAPI {
     vmID: string = undefined,
     fxIDs: string[] = undefined,
     genesisData: string | GenesisData = undefined,
-    subnetAuth: SubnetAuth = undefined,
     memo: PayloadBase | Buffer = undefined,
     asOf: BN = UnixNow()
   ): Promise<UnsignedTx> => {

--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -1913,7 +1913,6 @@ export class PlatformVMAPI extends JRPCAPI {
       vmID,
       fxIDs,
       genesisData,
-      subnetAuth,
       this.getCreateChainTxFee(),
       avaxAssetID,
       memo,

--- a/src/apis/platformvm/basetx.ts
+++ b/src/apis/platformvm/basetx.ts
@@ -115,7 +115,7 @@ export class BaseTx extends StandardBaseTx<KeyPair, KeyChain> {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = []
+    const creds: Credential[] = []
     for (let i: number = 0; i < this.ins.length; i++) {
       const cred: Credential = SelectCredentialClass(
         this.ins[`${i}`].getInput().getCredentialID()
@@ -128,9 +128,9 @@ export class BaseTx extends StandardBaseTx<KeyPair, KeyChain> {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       }
-      sigs.push(cred)
+      creds.push(cred)
     }
-    return sigs
+    return creds
   }
 
   clone(): this {

--- a/src/apis/platformvm/importtx.ts
+++ b/src/apis/platformvm/importtx.ts
@@ -134,7 +134,7 @@ export class ImportTx extends BaseTx {
    * @returns An array of [[Credential]]s
    */
   sign(msg: Buffer, kc: KeyChain): Credential[] {
-    const sigs: Credential[] = super.sign(msg, kc)
+    const creds: Credential[] = super.sign(msg, kc)
     for (let i: number = 0; i < this.importIns.length; i++) {
       const cred: Credential = SelectCredentialClass(
         this.importIns[`${i}`].getInput().getCredentialID()
@@ -147,9 +147,9 @@ export class ImportTx extends BaseTx {
         sig.fromBuffer(signval)
         cred.addSignature(sig)
       }
-      sigs.push(cred)
+      creds.push(cred)
     }
-    return sigs
+    return creds
   }
 
   clone(): this {

--- a/src/apis/platformvm/subnetauth.ts
+++ b/src/apis/platformvm/subnetauth.ts
@@ -28,7 +28,7 @@ export class SubnetAuth extends Serializable {
 
   /**
    * Add an address index for Subnet Auth signing
-   * 
+   *
    * @param index the Buffer of the address index to add
    */
   addAddressIndex(index: Buffer): void {

--- a/src/apis/platformvm/subnetauth.ts
+++ b/src/apis/platformvm/subnetauth.ts
@@ -27,6 +27,17 @@ export class SubnetAuth extends Serializable {
   }
 
   /**
+   * Add an address index for Subnet Auth signing
+   * 
+   * @param index the Buffer of the address index to add
+   */
+  addAddressIndex(index: Buffer): void {
+    const numAddrIndices: number = this.getNumAddressIndices()
+    this.numAddressIndices.writeUIntBE(numAddrIndices + 1, 0, 4)
+    this.addressIndices.push(index)
+  }
+
+  /**
    * Returns the number of address indices as a number
    */
   getNumAddressIndices(): number {
@@ -70,13 +81,5 @@ export class SubnetAuth extends Serializable {
       barr.push(this.addressIndices[`${i}`])
     })
     return Buffer.concat(barr, bsize)
-  }
-
-  constructor(addressIndices: Buffer[] = undefined) {
-    super()
-    if (typeof addressIndices !== "undefined") {
-      this.numAddressIndices.writeUIntBE(addressIndices.length, 0, 4)
-      this.addressIndices = addressIndices
-    }
   }
 }

--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -87,8 +87,8 @@ export class UnsignedTx extends StandardUnsignedTx<KeyPair, KeyChain, BaseTx> {
     const msg: Buffer = Buffer.from(
       createHash("sha256").update(txbuff).digest()
     )
-    const sigs: Credential[] = this.transaction.sign(msg, kc)
-    return new Tx(this, sigs)
+    const creds: Credential[] = this.transaction.sign(msg, kc)
+    return new Tx(this, creds)
   }
 }
 

--- a/src/apis/platformvm/utxos.ts
+++ b/src/apis/platformvm/utxos.ts
@@ -45,7 +45,7 @@ import {
   FeeAssetError,
   TimeError
 } from "../../utils/errors"
-import { CreateChainTx, SubnetAuth } from "."
+import { CreateChainTx } from "."
 import { GenesisData } from "../avm"
 import { AddSubnetValidatorTx } from "../platformvm/addsubnetvalidatortx"
 
@@ -1263,7 +1263,6 @@ export class UTXOSet extends StandardUTXOSet<UTXO> {
    * @param vmID Optional ID of the VM running on the new chain
    * @param fxIDs Optional IDs of the feature extensions running on the new chain
    * @param genesisData Optional Byte representation of genesis state of the new chain
-   * @param subnetAuth Optional Specifies the addresses whose signatures will be provided to demonstrate that the owners of a subnet approve something
    * @param fee Optional. The amount of fees to burn in its smallest denomination, represented as {@link https://github.com/indutny/bn.js/|BN}
    * @param feeAssetID Optional. The assetID of the fees being burned
    * @param memo Optional contains arbitrary bytes, up to 256 bytes
@@ -1281,7 +1280,6 @@ export class UTXOSet extends StandardUTXOSet<UTXO> {
     vmID: string = undefined,
     fxIDs: string[] = undefined,
     genesisData: string | GenesisData = undefined,
-    subnetAuth: SubnetAuth = undefined,
     fee: BN = undefined,
     feeAssetID: Buffer = undefined,
     memo: Buffer = undefined,
@@ -1322,8 +1320,7 @@ export class UTXOSet extends StandardUTXOSet<UTXO> {
       chainName,
       vmID,
       fxIDs,
-      genesisData,
-      subnetAuth
+      genesisData
     )
     return new UnsignedTx(createChainTx)
   }

--- a/tests/apis/platformvm/createchaintx.test.ts
+++ b/tests/apis/platformvm/createchaintx.test.ts
@@ -63,7 +63,7 @@ describe("CreateChainTx", () => {
   gd.fromBuffer(bintools.cb58Decode(genesisDataStr))
   const addressIndex: Buffer = Buffer.alloc(4)
   addressIndex.writeUIntBE(0x0, 0, 4)
-  const subnetAuth: SubnetAuth = new SubnetAuth([addressIndex])
+  const subnetAuth: SubnetAuth = new SubnetAuth()
   let keymgr1: KeyChain = new KeyChain(avalanche.getHRP(), alias)
   let keymgr2: KeyChain = new KeyChain(avalanche.getHRP(), alias)
   let keymgr3: KeyChain = new KeyChain(avalanche.getHRP(), alias)
@@ -133,8 +133,7 @@ describe("CreateChainTx", () => {
     chainNameStr,
     vmIDStr,
     fxIDsStr,
-    gd,
-    subnetAuth
+    gd
   )
   test("buildCreateChainTx", async (): Promise<void> => {
     const addrs1Strs: string[] = addrs1.map((a): string =>
@@ -149,7 +148,6 @@ describe("CreateChainTx", () => {
       vmIDStr,
       fxIDsStr,
       gd,
-      subnetAuth,
       memo
     )
     const payload: object = {
@@ -174,7 +172,6 @@ describe("CreateChainTx", () => {
       vmIDStr,
       fxIDsStr,
       gd,
-      subnetAuth,
       pchain.getCreateChainTxFee(),
       assetID,
       memo
@@ -190,7 +187,7 @@ describe("CreateChainTx", () => {
     expect(txType).toBe(PlatformVMConstants.CREATECHAINTX)
 
     const sa: SubnetAuth = tx.getSubnetAuth()
-    expect(sa).toBe(subnetAuth)
+    expect(sa).toStrictEqual(subnetAuth)
 
     const sID: string = tx.getSubnetID()
     expect(sID).toBe(subnetIDStr)
@@ -221,7 +218,7 @@ describe("CreateChainTx", () => {
   })
   test("createChainTx getSubnetAuth", (): void => {
     const sa: SubnetAuth = createChainTx.getSubnetAuth()
-    expect(sa).toBe(subnetAuth)
+    expect(sa).toStrictEqual(subnetAuth)
   })
   test("createChainTx getSubnetID", (): void => {
     const subnetID: string = createChainTx.getSubnetID()

--- a/tests/apis/platformvm/subnetauth.test.ts
+++ b/tests/apis/platformvm/subnetauth.test.ts
@@ -8,11 +8,7 @@ import BinTools from "src/utils/bintools"
 const bintools: BinTools = BinTools.getInstance()
 
 describe("SubnetAuth", (): void => {
-  const address1: Buffer = Buffer.alloc(4)
-  const address2: Buffer = Buffer.alloc(4)
-  address2.writeUIntBE(0x01, 0, 4)
-  const addresses: Buffer[] = [address1, address2]
-  const subnetAuth1: SubnetAuth = new SubnetAuth(addresses)
+  const subnetAuth1: SubnetAuth = new SubnetAuth()
   const subnetAuth2: SubnetAuth = new SubnetAuth()
 
   test("getters", (): void => {
@@ -21,6 +17,13 @@ describe("SubnetAuth", (): void => {
 
     const typeID: number = subnetAuth1.getTypeID()
     expect(typeID).toBe(10)
+
+    let addressIndex: Buffer = Buffer.alloc(4)
+    addressIndex.writeUIntBE(0, 0, 4)
+    subnetAuth1.addAddressIndex(addressIndex)
+    addressIndex = Buffer.alloc(4)
+    addressIndex.writeUIntBE(1, 0, 4)
+    subnetAuth1.addAddressIndex(addressIndex)
 
     const numAddressIndices: number = subnetAuth1.getNumAddressIndices()
     expect(numAddressIndices).toBe(2)

--- a/tests/apis/platformvm/tx.test.ts
+++ b/tests/apis/platformvm/tx.test.ts
@@ -101,7 +101,6 @@ describe("Transactions", (): void => {
   gd.fromBuffer(bintools.cb58Decode(genesisDataStr))
   const addressIndex: Buffer = Buffer.alloc(4)
   addressIndex.writeUIntBE(0x0, 0, 4)
-  const subnetAuth: SubnetAuth = new SubnetAuth([addressIndex])
   // let addSubnetValidatorTx: AddSubnetValidatorTx = new AddSubnetValidatorTx()
 
   beforeAll(async (): Promise<void> => {


### PR DESCRIPTION
* Add `avm/baseEndpoint.ts` example script
* Convert `sigs` var to `creds` to have code be more self-documenting
* Add `addAddressIndex` method to `SubnetAuth` class
* Update example `createSubnetTx.ts` script to
  * Create keychain w/ 3 keypairs
  * Create UTXO with 1-of-1
  * Create SubnetAuth with 2-of-2
* Update example `createChainTx.ts` script to
  * Create keychain w/ 3 keypairs
  * Consume and spend UTXO with 1-of-1
  * Sign SubnetAuth with 2-of-2
* Update `CreateChainTx` class
  * Add `addSignatureIdx` method
* Remove `SubnetAuth` parameter from `buildCreateChainTx`
* Update jest syntax
* Add example scripts for the multisig workflow.