### PR TITLE
Encoding a Bech32 address from a `Buffer`

### DIFF
--- a/examples/avm/addressFromBuffer.ts
+++ b/examples/avm/addressFromBuffer.ts
@@ -1,20 +1,44 @@
 import { Avalanche, Buffer } from "../../src"
 import { AVMAPI } from "../../src/apis/avm"
-
-const ip: string = "localhost"
-const port: number = 9650
-const protocol: string = "http"
-const networkID: number = 1337
-const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
+import { UTXOSet, UTXO } from "../../src/apis/platformvm"
+import { Output } from "../../src/common"
+// Change the networkID to affect the HRP of the bech32 encoded address
+// NetworkID - Bech32 Address - ChainPrefix-HRP1AddressChecksum
+//         0 - X-custom19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
+//         1 - X-avax19rknw8l0grnfunjrzwxlxync6zrlu33y2jxhrg
+//         2 - X-cascade19rknw8l0grnfunjrzwxlxync6zrlu33ypmtvnh
+//         3 - X-denali19rknw8l0grnfunjrzwxlxync6zrlu33yhc357h
+//         4 - X-everest19rknw8l0grnfunjrzwxlxync6zrlu33yn44wty
+//         5 - X-fuji19rknw8l0grnfunjrzwxlxync6zrlu33yxqzg0h
+//      1337 - X-custom19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
+//     12345 - X-local19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq
+const networkID: number = 12345
+const avalanche: Avalanche = new Avalanche(
+  undefined,
+  undefined,
+  undefined,
+  networkID
+)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const addressBuffer: Buffer = Buffer.from(
-    "3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c",
-    "hex"
-  )
-  const addressString: string = xchain.addressFromBuffer(addressBuffer)
-  console.log(addressString)
+  const utxoset: UTXOSet = new UTXOSet()
+  utxoset.addArray([
+    "11Zf8cc55Qy1rVgy3t87MJVCSEu539whRSwpdbrtHS6oh5Hnwv1gz8G3BtLJ73MPspLkD93cygZufT4TPYZCmuxW5cRdPrVMbZAHfb6uyGM1jNGBhBiQAgQ6V1yceYf825g27TT6WU4bTdbniWdECDWdGdi84hdiqSJH2y",
+    "11Zf8cc55Qy1rVgy3t87MJVCSEu539whRSwpdbrtHS6oh5Hnwv1NjNhqZnievVs2kBD9qTrayBYRs91emGTtmnu2wzqpLstbAPJDdVjf3kjwGWywNCdjV6TPGojVR5vHpJhBVRtHTQXR9VP9MBdHXge8zEBsQJAoZhTbr2"
+  ])
+  const utxos: UTXO[] = utxoset.getAllUTXOs()
+
+  utxos.map((utxo: UTXO): void => {
+    const output: Output = utxo.getOutput()
+    const addresses: string[] = output
+      .getAddresses()
+      .map((x: Buffer): string => {
+        const addy: string = xchain.addressFromBuffer(x)
+        return addy
+      })
+    console.log(addresses)
+  })
 }
 
 main()


### PR DESCRIPTION
Example script showing how to encode an `Address` `Buffer` as Bech32 including changing the HRP per the `networkID` which is passed when `Avalanche` is instantiated.