### PR TITLE
Add randombytes dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ethers": "5.6.4",
     "hdkey": "2.0.1",
     "isomorphic-ws": "4.0.1",
+    "randombytes": "^2.1.0",
     "store2": "2.13.2",
     "stream-browserify": "3.0.0",
     "ws": "8.5.0",


### PR DESCRIPTION
This PR adds `randombytes` as a dependency.

`randombytes` is imported at https://github.com/ava-labs/avalanchejs/blob/46ce89f395133702320a77cba4bb9cb818b48fe8/src/utils/mnemonic.ts#L10