### PR TITLE
Ds 206 make the sample can run independently outside avalanchejs project

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,30 +4,32 @@ on: push
 env:
   GOPATH: /home/runner/go
   AVAPATH: src/github.com/ava-labs
+  ACTIONS_RUNTIME_URL: 
+  ACTIONS_RUNTIME_TOKEN: 
+  ACTIONS_CACHE_URL: 
 
 jobs:
   e2e:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout AvalancheJS
-        # Uses the major version of a release of a public repository
         uses: actions/checkout@v2
-        # with ava-labs/avalanchejs
-      - name: Setup Node Version and Cache
-        uses: actions/setup-node@v2
-        with:
-          cache: yarn
-          node-version: '16'
+        with: 
+          repository: 'ava-labs/avalanchejs'
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install zstd git build-essential nodejs -y
       - name: Install NodeJS dependencies
         run: yarn install --frozen-lockfile
       - name: Setup GoLang Version
         uses: actions/setup-go@v1
         with:
-          go-version: '1.18.0'
+          go-version: '1.17.9'
       - name: Setup GOPATH and AVAPATH
         run : |
           mkdir -p $GOPATH
           mkdir -p $GOPATH/$AVAPATH
+      - name: Install autoremove
+        run: sudo apt-get autoremove -y
       - name: Clone and Build AvalancheGo
         run : |
           cd $GOPATH
@@ -36,13 +38,16 @@ jobs:
           cd avalanchego
           ./scripts/build.sh
       - name: Checkout ANR
-        uses: actions/checkout@v2
-        with:
-          repository: 'ava-labs/avalanche-network-runner'
-          path: 'avalanche-network-runner'
+        run : |
+          cd $GOPATH
+          cd $AVAPATH
+          git clone https://github.com/ava-labs/avalanche-network-runner
       - name: Starting ANR
         run: |
+          cd $GOPATH
+          cd $AVAPATH
           cd avalanche-network-runner
+          git checkout v1.0.12
           go run ./examples/local/fivenodenetwork/main.go &
       - name: AvalancheJS E2E Test
         env: 

--- a/examples/admin/alias.ts
+++ b/examples/admin/alias.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/aliasChain.ts
+++ b/examples/admin/aliasChain.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/getChainAliases.ts
+++ b/examples/admin/getChainAliases.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
-import { Defaults } from "../../src/utils"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
+import { Defaults } from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/getLoggerLevel.ts
+++ b/examples/admin/getLoggerLevel.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
-import { GetLoggerLevelResponse } from "../../src/apis/admin/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
+import { GetLoggerLevelResponse } from "avalanche/dist/apis/admin/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/loadVMs.ts
+++ b/examples/admin/loadVMs.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
-import { LoadVMsResponse } from "../../src/apis/admin/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
+import { LoadVMsResponse } from "avalanche/dist/apis/admin/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/lockProfile.ts
+++ b/examples/admin/lockProfile.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/memoryProfile.ts
+++ b/examples/admin/memoryProfile.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/setLoggerLevel.ts
+++ b/examples/admin/setLoggerLevel.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
-import { SetLoggerLevelResponse } from "../../src/apis/admin/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
+import { SetLoggerLevelResponse } from "avalanche/dist/apis/admin/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/startCPUProfiler.ts
+++ b/examples/admin/startCPUProfiler.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/admin/stopCPUProfiler.ts
+++ b/examples/admin/stopCPUProfiler.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AdminAPI } from "../../src/apis/admin"
+import { Avalanche } from "avalanche/dist"
+import { AdminAPI } from "avalanche/dist/apis/admin"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/auth/changePassword.ts
+++ b/examples/auth/changePassword.ts
@@ -2,8 +2,8 @@
 // which you can create based on "secrets.example" which is in the
 // root of the `examples/` directory.
 // Unlike "secrets.example", "secrets.json" should never be committed to git.
-import { Avalanche } from "../../src"
-import { AuthAPI } from "../../src/apis/auth"
+import { Avalanche } from "avalanche/dist"
+import { AuthAPI } from "avalanche/dist/apis/auth"
 import { readFile } from "fs"
 
 const ip: string = "localhost"

--- a/examples/auth/newToken.ts
+++ b/examples/auth/newToken.ts
@@ -3,9 +3,9 @@
 // root of the `examples/` directory.
 // Unlike "secrets.example", "secrets.json" should never be committed to git.
 import { readFile } from "fs"
-import { Avalanche } from "../../src"
-import { AuthAPI } from "../../src/apis/auth"
-import { ErrorResponseObject } from "../../src/utils"
+import { Avalanche } from "avalanche/dist"
+import { AuthAPI } from "avalanche/dist/apis/auth"
+import { ErrorResponseObject } from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/auth/revokeToken.ts
+++ b/examples/auth/revokeToken.ts
@@ -3,8 +3,8 @@
 // root of the `examples/` directory.
 // Unlike "secrets.example", "secrets.json" should never be committed to git.
 import { readFile } from "fs"
-import { Avalanche } from "../../src"
-import { AuthAPI } from "../../src/apis/auth"
+import { Avalanche } from "avalanche/dist"
+import { AuthAPI } from "avalanche/dist/apis/auth"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/addressFromBuffer.ts
+++ b/examples/avm/addressFromBuffer.ts
@@ -1,7 +1,7 @@
-import { Avalanche, Buffer } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
-import { UTXOSet, UTXO } from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
+import { Avalanche, Buffer } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
+import { UTXOSet, UTXO } from "avalanche/dist/apis/platformvm"
+import { Output } from "avalanche/dist/common"
 // Change the networkID to affect the HRP of the bech32 encoded address
 // NetworkID - Bech32 Address - ChainPrefix-HRP1AddressChecksum
 //         0 - X-custom19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya

--- a/examples/avm/baseEndpoint.ts
+++ b/examples/avm/baseEndpoint.ts
@@ -1,4 +1,4 @@
-import { Avalanche } from "../../src"
+import { Avalanche } from "avalanche/dist"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   BaseTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   Defaults,
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,13 +12,13 @@ import {
   UnsignedTx,
   Tx,
   BaseTx
-} from "../../src/apis/avm"
-import { GetBalanceResponse } from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/avm"
+import { GetBalanceResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   BaseTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -1,5 +1,5 @@
 import createHash from "create-hash"
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -13,12 +13,12 @@ import {
   UnsignedTx,
   Tx,
   BaseTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"

--- a/examples/avm/buildBaseTx-ant.ts
+++ b/examples/avm/buildBaseTx-ant.ts
@@ -1,11 +1,11 @@
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
-import { Avalanche, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "../../src/apis/avm"
-import { UnixNow } from "../../src/utils"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import { UnixNow } from "avalanche/dist/utils"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildBaseTx-ant.ts
+++ b/examples/avm/buildBaseTx-ant.ts
@@ -1,6 +1,12 @@
 import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import { Avalanche, BN, Buffer } from "avalanche/dist"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import {
+  AVMAPI,
+  KeyChain,
+  UTXOSet,
+  UnsignedTx,
+  Tx
+} from "avalanche/dist/apis/avm"
 import { UnixNow } from "avalanche/dist/utils"
 import {
   PrivateKeyPrefix,

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -1,5 +1,11 @@
 import { Avalanche, BN, Buffer } from "avalanche/dist"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import {
+  AVMAPI,
+  KeyChain,
+  UTXOSet,
+  UnsignedTx,
+  Tx
+} from "avalanche/dist/apis/avm"
 import {
   GetBalanceResponse,
   GetUTXOsResponse

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -1,15 +1,15 @@
-import { Avalanche, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "../../src/apis/avm"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
 import {
   GetBalanceResponse,
   GetUTXOsResponse
-} from "../../src/apis/avm/interfaces"
-import { Defaults } from "../../src/utils"
+} from "avalanche/dist/apis/avm/interfaces"
+import { Defaults } from "avalanche/dist/utils"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildCreateAssetTx.ts
+++ b/examples/avm/buildCreateAssetTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -8,12 +8,12 @@ import {
   InitialStates,
   SECPMintOutput,
   SECPTransferOutput
-} from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildCreateNFTAssetTx.ts
+++ b/examples/avm/buildCreateNFTAssetTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain as AVMKeyChain,
@@ -6,13 +6,13 @@ import {
   UnsignedTx,
   Tx,
   MinterSet
-} from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildCreateNFTMintTx.ts
+++ b/examples/avm/buildCreateNFTMintTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -7,14 +7,14 @@ import {
   Tx,
   AVMConstants,
   UTXO
-} from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
-import { OutputOwners } from "../../src/common"
+} from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
+import { OutputOwners } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 // run ts-node examples/avm/buildCreateNFTMintTx.ts
 // before you run this example buildCreateNFTAssetTx.ts

--- a/examples/avm/buildExportTx-PChain.ts
+++ b/examples/avm/buildExportTx-PChain.ts
@@ -1,25 +1,25 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain as AVMKeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   GetBalanceResponse,
   GetUTXOsResponse
-} from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/avm/interfaces"
 import {
   KeyChain as PlatformVMKeyChain,
   PlatformVMAPI
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildExportTx-cchain-ant.ts
+++ b/examples/avm/buildExportTx-cchain-ant.ts
@@ -1,19 +1,19 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain as AVMKeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
-import { KeyChain as EVMKeyChain, EVMAPI } from "../../src/apis/evm"
+} from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
+import { KeyChain as EVMKeyChain, EVMAPI } from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildExportTx-cchain-avax.ts
+++ b/examples/avm/buildExportTx-cchain-avax.ts
@@ -1,22 +1,22 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain as AVMKeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   GetBalanceResponse,
   GetUTXOsResponse
-} from "../../src/apis/avm/interfaces"
-import { KeyChain as EVMKeyChain, EVMAPI } from "../../src/apis/evm"
+} from "avalanche/dist/apis/avm/interfaces"
+import { KeyChain as EVMKeyChain, EVMAPI } from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildImportTx-PChain.ts
+++ b/examples/avm/buildImportTx-PChain.ts
@@ -1,12 +1,12 @@
-import { Avalanche, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildImportTx-PChain.ts
+++ b/examples/avm/buildImportTx-PChain.ts
@@ -1,5 +1,11 @@
 import { Avalanche, BN, Buffer } from "avalanche/dist"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import {
+  AVMAPI,
+  KeyChain,
+  UTXOSet,
+  UnsignedTx,
+  Tx
+} from "avalanche/dist/apis/avm"
 import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,

--- a/examples/avm/buildImportTx-cchain.ts
+++ b/examples/avm/buildImportTx-cchain.ts
@@ -1,12 +1,12 @@
-import { Avalanche, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/buildImportTx-cchain.ts
+++ b/examples/avm/buildImportTx-cchain.ts
@@ -1,5 +1,11 @@
 import { Avalanche, BN, Buffer } from "avalanche/dist"
-import { AVMAPI, KeyChain, UTXOSet, UnsignedTx, Tx } from "avalanche/dist/apis/avm"
+import {
+  AVMAPI,
+  KeyChain,
+  UTXOSet,
+  UnsignedTx,
+  Tx
+} from "avalanche/dist/apis/avm"
 import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,

--- a/examples/avm/buildNFTTransferTx.ts
+++ b/examples/avm/buildNFTTransferTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -7,13 +7,13 @@ import {
   Tx,
   AVMConstants,
   UTXO
-} from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const getUTXOIDs = (
   utxoSet: UTXOSet,

--- a/examples/avm/buildSECPMintTx.ts
+++ b/examples/avm/buildSECPMintTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -9,13 +9,13 @@ import {
   AVMConstants,
   SECPTransferOutput,
   UTXO
-} from "../../src/apis/avm"
-import { GetUTXOsResponse } from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/avm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 // assetID is generated from running
 // ts-node examples/avm/buildCreateAssetTx.ts

--- a/examples/avm/createAddress.ts
+++ b/examples/avm/createAddress.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain as AVMKeyChain,
@@ -14,12 +14,12 @@ import {
   CreateAssetTx,
   SECPMintOutput,
   InitialStates
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -16,12 +16,12 @@ import {
   AVMConstants,
   MinterSet,
   NFTMintOutput
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/createKeypair.ts
+++ b/examples/avm/createKeypair.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI, KeyChain, KeyPair } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI, KeyChain, KeyPair } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/createTXID.ts
+++ b/examples/avm/createTXID.ts
@@ -1,24 +1,24 @@
 import createHash from "create-hash"
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain as AVMKeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   KeyChain as PlatformVMKeyChain,
   PlatformVMAPI
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow,
   SerializedType
-} from "../../src/utils"
-import { Serialization } from "../../src/utils"
+} from "avalanche/dist/utils"
+import { Serialization } from "avalanche/dist/utils"
 
 const serialization: Serialization = Serialization.getInstance()
 const ip: string = "localhost"

--- a/examples/avm/exportTx-ant-cchain.ts
+++ b/examples/avm/exportTx-ant-cchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/exportTx-avax-to-the-pchain-and-create-a-multisig-atomic-utxo.ts
+++ b/examples/avm/exportTx-avax-to-the-pchain-and-create-a-multisig-atomic-utxo.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,16 +12,16 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PlatformVMAPI,
   KeyChain as PlatformVMKeyChain
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/genesisData.ts
+++ b/examples/avm/genesisData.ts
@@ -1,4 +1,4 @@
-import Avalanche, { BN, Buffer } from "../../src"
+import Avalanche, { BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   GenesisAsset,
@@ -7,13 +7,13 @@ import {
   KeyChain,
   SECPMintOutput,
   SECPTransferOutput
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   DefaultLocalGenesisPrivateKey,
   PrivateKeyPrefix,
   Serialization,
   SerializedType
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 const serialization: Serialization = Serialization.getInstance()
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getAVAXAssetID.ts
+++ b/examples/avm/getAVAXAssetID.ts
@@ -1,5 +1,5 @@
-import { Avalanche, Buffer } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche, Buffer } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getAllBalances.ts
+++ b/examples/avm/getAllBalances.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getAssetDescription.ts
+++ b/examples/avm/getAssetDescription.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getBalance.ts
+++ b/examples/avm/getBalance.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getBlockchainAlias.ts
+++ b/examples/avm/getBlockchainAlias.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getBlockchainID.ts
+++ b/examples/avm/getBlockchainID.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getCreationTxFee.ts
+++ b/examples/avm/getCreationTxFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getDefaultCreationTxFee.ts
+++ b/examples/avm/getDefaultCreationTxFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getDefaultTxFee.ts
+++ b/examples/avm/getDefaultTxFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getInterfaces.ts
+++ b/examples/avm/getInterfaces.ts
@@ -1,4 +1,4 @@
-import { SendResponse } from "../../src/apis/avm"
+import { SendResponse } from "avalanche/dist/apis/avm"
 
 const main = async (): Promise<any> => {
   const sendResponse: SendResponse = {

--- a/examples/avm/getTx.ts
+++ b/examples/avm/getTx.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getTxFee.ts
+++ b/examples/avm/getTxFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/getTxStatus.ts
+++ b/examples/avm/getTxStatus.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/importTx-cchain.ts
+++ b/examples/avm/importTx-cchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ImportTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ImportTx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/keyChain.ts
+++ b/examples/avm/keyChain.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI, KeyChain } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI, KeyChain } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/listAddresses.ts
+++ b/examples/avm/listAddresses.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { AVMAPI } from "../../src/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/newKeyChain.ts
+++ b/examples/avm/newKeyChain.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { AVMAPI, KeyChain } from "../../dist/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI, KeyChain } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   KeyChain,
@@ -16,12 +16,12 @@ import {
   SECPMintOutput,
   TransferableOperation,
   Tx
-} from "../../src/apis/avm"
+} from "avalanche/dist/apis/avm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 // before you run this example buildCreateNFTAssetTx.ts
 

--- a/examples/avm/operationTx-mint-nft.ts
+++ b/examples/avm/operationTx-mint-nft.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   AVMAPI,
   SECPTransferOutput,
@@ -16,13 +16,13 @@ import {
   KeyChain,
   NFTMintOperation,
   NFTMintOutput
-} from "../../src/apis/avm"
-import { OutputOwners } from "../../src/common"
+} from "avalanche/dist/apis/avm"
+import { OutputOwners } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 // before you run this example buildCreateNFTAssetTx.ts
 

--- a/examples/avm/parseAddress.ts
+++ b/examples/avm/parseAddress.ts
@@ -1,5 +1,5 @@
-import { Avalanche, Buffer } from "../../dist"
-import { AVMAPI } from "../../dist/apis/avm"
+import { Avalanche, Buffer } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/refreshBlockchainID.ts
+++ b/examples/avm/refreshBlockchainID.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { AVMAPI } from "../../dist/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/setAVAXAssetID.ts
+++ b/examples/avm/setAVAXAssetID.ts
@@ -1,5 +1,5 @@
-import { Avalanche, Buffer } from "../../dist"
-import { AVMAPI } from "../../dist/apis/avm"
+import { Avalanche, Buffer } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/setBlockchainAlias.ts
+++ b/examples/avm/setBlockchainAlias.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { AVMAPI } from "../../dist/apis/avm"
+import { Avalanche } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/setCreationTxFee.ts
+++ b/examples/avm/setCreationTxFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../dist"
-import { AVMAPI } from "../../dist/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/avm/setTxFee.ts
+++ b/examples/avm/setTxFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../dist"
-import { AVMAPI } from "../../dist/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI } from "avalanche/dist/apis/avm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/bintools/isBase58.ts
+++ b/examples/bintools/isBase58.ts
@@ -1,4 +1,4 @@
-import { BinTools } from "../../src"
+import { BinTools } from "avalanche/dist"
 const bintools: BinTools = BinTools.getInstance()
 const validBase581: string = "isGvtnDqETNmmFw7guSJ7mmWhCqboExrpmC8VsWxckHcH9oXb"
 const validBase582: string =

--- a/examples/bintools/isCB58.ts
+++ b/examples/bintools/isCB58.ts
@@ -1,4 +1,4 @@
-import { BinTools } from "../../src"
+import { BinTools } from "avalanche/dist"
 const bintools: BinTools = BinTools.getInstance()
 const validCB581: string = "isGvtnDqETNmmFw7guSJ7mmWhCqboExrpmC8VsWxckHcH9oXb"
 const validCB582: string = "2PwX8qwMHbwVAm28howu3Ef7Lk4ib2XG7AaY9aK8dTTGNXQkCz"

--- a/examples/bintools/isHex.ts
+++ b/examples/bintools/isHex.ts
@@ -1,4 +1,4 @@
-import { BinTools } from "../../src"
+import { BinTools } from "avalanche/dist"
 const bintools: BinTools = BinTools.getInstance()
 const validHex1: string =
   "0x95eaac2b7a6ee7ad7e597c2f5349b03e461c36c2e1e50fc98a84d01612940bd5"

--- a/examples/evm/buildExportTx-pchain.ts
+++ b/examples/evm/buildExportTx-pchain.ts
@@ -1,20 +1,20 @@
-import { Avalanche, BN } from "../../src"
+import { Avalanche, BN } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain as PlatformKeyChain
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
   UnsignedTx,
   Tx
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   costExportTx
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/buildExportTx-xchain-ant.ts
+++ b/examples/evm/buildExportTx-xchain-ant.ts
@@ -1,17 +1,17 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
   UnsignedTx,
   Tx
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   costExportTx
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/buildExportTx-xchain-avax.ts
+++ b/examples/evm/buildExportTx-xchain-avax.ts
@@ -1,17 +1,17 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
   UnsignedTx,
   Tx
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   costExportTx
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/buildImportTx-PChain.ts
+++ b/examples/evm/buildImportTx-PChain.ts
@@ -1,21 +1,21 @@
-import { Avalanche, BN } from "../../src"
+import { Avalanche, BN } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain as PlatformVMKeyChain
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
   UnsignedTx,
   Tx,
   UTXOSet
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   costImportTx
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/buildImportTx-xchain.ts
+++ b/examples/evm/buildImportTx-xchain.ts
@@ -1,18 +1,18 @@
-import { Avalanche, BN } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BN } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
   UnsignedTx,
   Tx,
   UTXOSet
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   costImportTx
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/createKeypair.ts
+++ b/examples/evm/createKeypair.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { EVMAPI, KeyChain, KeyPair } from "../../src/apis/evm"
-import { CreateKeyPairResponse } from "../../src/apis/evm/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { EVMAPI, KeyChain, KeyPair } from "avalanche/dist/apis/evm"
+import { CreateKeyPairResponse } from "avalanche/dist/apis/evm/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/exportTx-ant-xchain.ts
+++ b/examples/evm/exportTx-ant-xchain.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
@@ -9,13 +9,13 @@ import {
   ExportTx,
   SECPTransferOutput,
   TransferableOutput
-} from "../../src/apis/evm"
-import { RequestResponseData } from "../../src/common"
+} from "avalanche/dist/apis/evm"
+import { RequestResponseData } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/exportTx-avax-pchain-create-multisig-atomic-output.ts
+++ b/examples/evm/exportTx-avax-pchain-create-multisig-atomic-output.ts
@@ -1,8 +1,8 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain as PlatformVMKeyChain
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
@@ -12,13 +12,13 @@ import {
   ExportTx,
   SECPTransferOutput,
   TransferableOutput
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   ONEAVAX
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 const Web3 = require("web3")
 
 const ip: string = "localhost"

--- a/examples/evm/exportTx-avax-xchain.ts
+++ b/examples/evm/exportTx-avax-xchain.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   EVMAPI,
   KeyChain as EVMKeyChain,
@@ -9,12 +9,12 @@ import {
   ExportTx,
   SECPTransferOutput,
   TransferableOutput
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/getAssetBalance.ts
+++ b/examples/evm/getAssetBalance.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { EVMAPI } from "../../src/apis/evm"
+import { Avalanche } from "avalanche/dist"
+import { EVMAPI } from "avalanche/dist/apis/evm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/getAtomicTx.ts
+++ b/examples/evm/getAtomicTx.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { EVMAPI } from "../../src/apis/evm"
+import { Avalanche } from "avalanche/dist"
+import { EVMAPI } from "avalanche/dist/apis/evm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/getAtomicTxStatus.ts
+++ b/examples/evm/getAtomicTxStatus.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { EVMAPI } from "../../src/apis/evm"
+import { Avalanche } from "avalanche/dist"
+import { EVMAPI } from "avalanche/dist/apis/evm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/getBaseFee.ts
+++ b/examples/evm/getBaseFee.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { EVMAPI } from "../../src/apis/evm"
+import { Avalanche, BN } from "avalanche/dist"
+import { EVMAPI } from "avalanche/dist/apis/evm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/getInterfaces.ts
+++ b/examples/evm/getInterfaces.ts
@@ -1,4 +1,4 @@
-import { GetAtomicTxParams } from "../../src/apis/evm"
+import { GetAtomicTxParams } from "avalanche/dist/apis/evm"
 
 const main = async (): Promise<any> => {
   const getAtomicTxParams: GetAtomicTxParams = {

--- a/examples/evm/getMaxPriorityFeePerGas.ts
+++ b/examples/evm/getMaxPriorityFeePerGas.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { EVMAPI } from "../../src/apis/evm"
+import { Avalanche, BN } from "avalanche/dist"
+import { EVMAPI } from "avalanche/dist/apis/evm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/importTx-avax-to-the-pchain-and-consume-a-multisig-output.ts
+++ b/examples/evm/importTx-avax-to-the-pchain-and-consume-a-multisig-output.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   EVMAPI,
   EVMOutput,
@@ -11,12 +11,12 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/evm/importTx-xchain.ts
+++ b/examples/evm/importTx-xchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   EVMAPI,
   EVMOutput,
@@ -11,12 +11,12 @@ import {
   AmountOutput,
   UnsignedTx,
   Tx
-} from "../../src/apis/evm"
+} from "avalanche/dist/apis/evm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/hdnode/derive.ts
+++ b/examples/hdnode/derive.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 
 const main = async (): Promise<any> => {
   const seed: string =

--- a/examples/hdnode/fromMasterSeedBuffer.ts
+++ b/examples/hdnode/fromMasterSeedBuffer.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 import { Buffer } from "buffer/"
 
 const main = async (): Promise<any> => {

--- a/examples/hdnode/fromMasterSeedString.ts
+++ b/examples/hdnode/fromMasterSeedString.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 
 const main = async (): Promise<any> => {
   const seed: string =

--- a/examples/hdnode/fromXPriv.ts
+++ b/examples/hdnode/fromXPriv.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 
 const main = async (): Promise<any> => {
   const xpriv: string =

--- a/examples/hdnode/fromXPub.ts
+++ b/examples/hdnode/fromXPub.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 
 const main = async (): Promise<any> => {
   const xpub: string =

--- a/examples/hdnode/sign.ts
+++ b/examples/hdnode/sign.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 import { Buffer } from "buffer/"
 
 const main = async (): Promise<any> => {

--- a/examples/hdnode/verify.ts
+++ b/examples/hdnode/verify.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 import { Buffer } from "buffer/"
 
 const main = async (): Promise<any> => {

--- a/examples/hdnode/wipePrivateData.ts
+++ b/examples/hdnode/wipePrivateData.ts
@@ -1,4 +1,4 @@
-import HDNode from "../../src/utils/hdnode"
+import HDNode from "avalanche/dist/utils/hdnode"
 
 const main = async (): Promise<any> => {
   const seed: string =

--- a/examples/health/health.ts
+++ b/examples/health/health.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../dist"
-import { HealthAPI } from "../../dist/apis/health"
-import { HealthResponse } from "../../dist/apis/health/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { HealthAPI } from "avalanche/dist/apis/health"
+import { HealthResponse } from "avalanche/dist/apis/health/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/index/getContainerByID.ts
+++ b/examples/index/getContainerByID.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { IndexAPI } from "../../src/apis/index"
-import { GetContainerByIDResponse } from "../../src/apis/index/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { IndexAPI } from "avalanche/dist/apis/index"
+import { GetContainerByIDResponse } from "avalanche/dist/apis/index/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/index/getContainerByIndex.ts
+++ b/examples/index/getContainerByIndex.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { IndexAPI } from "../../src/apis/index"
-import { GetContainerByIndexResponse } from "../../src/apis/index/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { IndexAPI } from "avalanche/dist/apis/index"
+import { GetContainerByIndexResponse } from "avalanche/dist/apis/index/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/index/getContainerRange.ts
+++ b/examples/index/getContainerRange.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { IndexAPI } from "../../src/apis/index"
-import { GetContainerRangeResponse } from "../../src/apis/index/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { IndexAPI } from "avalanche/dist/apis/index"
+import { GetContainerRangeResponse } from "avalanche/dist/apis/index/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/index/getIndex.ts
+++ b/examples/index/getIndex.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { IndexAPI } from "../../src/apis/index"
+import { Avalanche } from "avalanche/dist"
+import { IndexAPI } from "avalanche/dist/apis/index"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/index/getLastAccepted.ts
+++ b/examples/index/getLastAccepted.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { IndexAPI } from "../../src/apis/index"
-import { GetLastAcceptedResponse } from "../../src/apis/index/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { IndexAPI } from "avalanche/dist/apis/index"
+import { GetLastAcceptedResponse } from "avalanche/dist/apis/index/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/index/isAccepted.ts
+++ b/examples/index/isAccepted.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { IndexAPI } from "../../src/apis/index"
-import { IsAcceptedResponse } from "../../src/apis/index/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { IndexAPI } from "avalanche/dist/apis/index"
+import { IsAcceptedResponse } from "avalanche/dist/apis/index/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/getBlockchainID.ts
+++ b/examples/info/getBlockchainID.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { InfoAPI } from "../../dist/apis/info"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/getNetworkID.ts
+++ b/examples/info/getNetworkID.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { InfoAPI } from "../../dist/apis/info"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/getNetworkName.ts
+++ b/examples/info/getNetworkName.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { InfoAPI } from "../../dist/apis/info"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/getNodeID.ts
+++ b/examples/info/getNodeID.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { InfoAPI } from "../../dist/apis/info"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/getNodeVersion.ts
+++ b/examples/info/getNodeVersion.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { InfoAPI } from "../../src/apis/info"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/getTxFee.ts
+++ b/examples/info/getTxFee.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { InfoAPI } from "../../src/apis/info"
-import { GetTxFeeResponse } from "../../src/apis/info/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
+import { GetTxFeeResponse } from "avalanche/dist/apis/info/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/isBootstrapped.ts
+++ b/examples/info/isBootstrapped.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { InfoAPI } from "../../dist/apis/info"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/peers.ts
+++ b/examples/info/peers.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { InfoAPI } from "../../src/apis/info"
-import { PeersResponse } from "../../src/apis/info/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
+import { PeersResponse } from "avalanche/dist/apis/info/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/info/uptime.ts
+++ b/examples/info/uptime.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../dist"
-import { InfoAPI } from "../../dist/apis/info"
-import { UptimeResponse } from "../../dist/apis/info/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { InfoAPI } from "avalanche/dist/apis/info"
+import { UptimeResponse } from "avalanche/dist/apis/info/interfaces"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/keystore/createUser.ts
+++ b/examples/keystore/createUser.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { KeystoreAPI } from "../../dist/apis/keystore"
+import { Avalanche } from "avalanche/dist"
+import { KeystoreAPI } from "avalanche/dist/apis/keystore"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/keystore/deleteUser.ts
+++ b/examples/keystore/deleteUser.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { KeystoreAPI } from "../../dist/apis/keystore"
+import { Avalanche } from "avalanche/dist"
+import { KeystoreAPI } from "avalanche/dist/apis/keystore"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/keystore/exportUser.ts
+++ b/examples/keystore/exportUser.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { KeystoreAPI } from "../../dist/apis/keystore"
+import { Avalanche } from "avalanche/dist"
+import { KeystoreAPI } from "avalanche/dist/apis/keystore"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/keystore/importUser.ts
+++ b/examples/keystore/importUser.ts
@@ -3,8 +3,8 @@
 // root of the `examples/` directory.
 // Unlike "secrets.example", "secrets.json" should never be committed to git.
 import { readFile } from "fs"
-import { Avalanche } from "../../dist"
-import { KeystoreAPI } from "../../dist/apis/keystore"
+import { Avalanche } from "avalanche/dist"
+import { KeystoreAPI } from "avalanche/dist/apis/keystore"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/keystore/listUsers.ts
+++ b/examples/keystore/listUsers.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { KeystoreAPI } from "../../dist/apis/keystore"
+import { Avalanche } from "avalanche/dist"
+import { KeystoreAPI } from "avalanche/dist/apis/keystore"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/metrics/getMetrics.ts
+++ b/examples/metrics/getMetrics.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { MetricsAPI } from "../../dist/apis/metrics"
+import { Avalanche } from "avalanche/dist"
+import { MetricsAPI } from "avalanche/dist/apis/metrics"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/mnemonic/entropyToMnemonic.ts
+++ b/examples/mnemonic/entropyToMnemonic.ts
@@ -1,4 +1,4 @@
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/generateMnemonic.ts
+++ b/examples/mnemonic/generateMnemonic.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "randombytes"
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/getDefaultWordlist.ts
+++ b/examples/mnemonic/getDefaultWordlist.ts
@@ -1,4 +1,4 @@
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/getWordlists.ts
+++ b/examples/mnemonic/getWordlists.ts
@@ -1,4 +1,4 @@
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/mnemonicToEntropy.ts
+++ b/examples/mnemonic/mnemonicToEntropy.ts
@@ -1,4 +1,4 @@
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/mnemonicToSeed.ts
+++ b/examples/mnemonic/mnemonicToSeed.ts
@@ -1,5 +1,5 @@
-import Mnemonic from "../../src/utils/mnemonic"
-import { Buffer } from "../../src"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
+import { Buffer } from "avalanche/dist"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/mnemonicToSeedSync.ts
+++ b/examples/mnemonic/mnemonicToSeedSync.ts
@@ -1,5 +1,5 @@
-import Mnemonic from "../../src/utils/mnemonic"
-import { Buffer } from "../../src"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
+import { Buffer } from "avalanche/dist"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/setDefaultWordlist.ts
+++ b/examples/mnemonic/setDefaultWordlist.ts
@@ -1,4 +1,4 @@
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/mnemonic/validateMnemonic.ts
+++ b/examples/mnemonic/validateMnemonic.ts
@@ -1,4 +1,4 @@
-import Mnemonic from "../../src/utils/mnemonic"
+import Mnemonic from "avalanche/dist/utils/mnemonic"
 const mnemonic: Mnemonic = Mnemonic.getInstance()
 
 const main = async (): Promise<any> => {

--- a/examples/platformvm/addDelegatorTx.ts
+++ b/examples/platformvm/addDelegatorTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -14,15 +14,15 @@ import {
   Tx,
   SECPOwnerOutput,
   ParseableOutput
-} from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
+} from "avalanche/dist/apis/platformvm"
+import { Output } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   NodeIDStringToBuffer,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/addSubnetValidatorTx.ts
+++ b/examples/platformvm/addSubnetValidatorTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -12,13 +12,13 @@ import {
   UnsignedTx,
   Tx,
   AddSubnetValidatorTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   NodeIDStringToBuffer,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"

--- a/examples/platformvm/addValidatorTx.ts
+++ b/examples/platformvm/addValidatorTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -14,15 +14,15 @@ import {
   Tx,
   SECPOwnerOutput,
   ParseableOutput
-} from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
+} from "avalanche/dist/apis/platformvm"
+import { Output } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   NodeIDStringToBuffer,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/baseTx-avax-create-multisig.ts
+++ b/examples/platformvm/baseTx-avax-create-multisig.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -12,13 +12,13 @@ import {
   UnsignedTx,
   Tx,
   BaseTx
-} from "../../src/apis/platformvm"
-import { GetBalanceResponse } from "../../src/apis/avm/interfaces"
+} from "avalanche/dist/apis/platformvm"
+import { GetBalanceResponse } from "avalanche/dist/apis/avm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"

--- a/examples/platformvm/buildAddDelegatorTx.ts
+++ b/examples/platformvm/buildAddDelegatorTx.ts
@@ -1,16 +1,16 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildAddSubnetValidatorTx.ts
+++ b/examples/platformvm/buildAddSubnetValidatorTx.ts
@@ -1,17 +1,17 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
-import { GetUTXOsResponse } from "../../src/apis/platformvm/interfaces"
+} from "avalanche/dist/apis/platformvm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/platformvm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildAddValidatorTx.ts
+++ b/examples/platformvm/buildAddValidatorTx.ts
@@ -1,16 +1,16 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildCreateChainTx.ts
+++ b/examples/platformvm/buildCreateChainTx.ts
@@ -1,16 +1,16 @@
-import { Avalanche, BinTools, BN, Buffer, GenesisData } from "../../src"
+import { Avalanche, BinTools, BN, Buffer, GenesisData } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 /**
  * @ignore

--- a/examples/platformvm/buildCreateSubnetTx.ts
+++ b/examples/platformvm/buildCreateSubnetTx.ts
@@ -1,17 +1,17 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
-import { GetUTXOsResponse } from "../../src/apis/platformvm/interfaces"
+} from "avalanche/dist/apis/platformvm"
+import { GetUTXOsResponse } from "avalanche/dist/apis/platformvm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildExportTx-CChain.ts
+++ b/examples/platformvm/buildExportTx-CChain.ts
@@ -1,18 +1,18 @@
-import { Avalanche, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildExportTx-XChain.ts
+++ b/examples/platformvm/buildExportTx-XChain.ts
@@ -1,18 +1,18 @@
-import { Avalanche, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildImportTx-CChain.ts
+++ b/examples/platformvm/buildImportTx-CChain.ts
@@ -1,17 +1,17 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist//utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/buildImportTx-XChain.ts
+++ b/examples/platformvm/buildImportTx-XChain.ts
@@ -1,17 +1,17 @@
-import { Avalanche, BN, Buffer } from "../../src"
+import { Avalanche, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
   UTXOSet,
   UnsignedTx,
   Tx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   UnixNow
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/createChainTx.ts
+++ b/examples/platformvm/createChainTx.ts
@@ -5,8 +5,8 @@ import {
   Buffer,
   GenesisAsset,
   GenesisData
-} from "../../src"
-import { InitialStates } from "../../src/apis/avm"
+} from "avalanche/dist"
+import { InitialStates } from "avalanche/dist/apis/avm"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -20,13 +20,13 @@ import {
   UnsignedTx,
   CreateChainTx,
   Tx
-} from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
+} from "avalanche/dist/apis/platformvm"
+import { Output } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   ONEAVAX
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const bintools: BinTools = BinTools.getInstance()
 const ip: string = "localhost"

--- a/examples/platformvm/createKeypair.ts
+++ b/examples/platformvm/createKeypair.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI, KeyChain, KeyPair } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI, KeyChain, KeyPair } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/createKeypair.ts
+++ b/examples/platformvm/createKeypair.ts
@@ -1,5 +1,9 @@
 import { Avalanche } from "avalanche/dist"
-import { PlatformVMAPI, KeyChain, KeyPair } from "avalanche/dist/apis/platformvm"
+import {
+  PlatformVMAPI,
+  KeyChain,
+  KeyPair
+} from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/createSubnetTx.ts
+++ b/examples/platformvm/createSubnetTx.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -13,12 +13,12 @@ import {
   CreateSubnetTx,
   Tx,
   SECPOwnerOutput
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
+++ b/examples/platformvm/exportTx-AVAX-from-the-cchain-and-create-a-multisig-atomic-output.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { EVMAPI, KeyChain as EVMKeyChain } from "../../src/apis/evm"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
+import { EVMAPI, KeyChain as EVMKeyChain } from "avalanche/dist/apis/evm"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -13,13 +13,13 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   MILLIAVAX
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/exportTx-cchain.ts
+++ b/examples/platformvm/exportTx-cchain.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { EVMAPI, KeyChain as EVMKeyChain } from "../../src/apis/evm"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
+import { EVMAPI, KeyChain as EVMKeyChain } from "avalanche/dist/apis/evm"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -13,13 +13,13 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   MILLIAVAX
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/exportTx-xchain.ts
+++ b/examples/platformvm/exportTx-xchain.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
-import { AVMAPI, KeyChain as AVMKeyChain } from "../../src/apis/avm"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
+import { AVMAPI, KeyChain as AVMKeyChain } from "avalanche/dist/apis/avm"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -13,14 +13,14 @@ import {
   UnsignedTx,
   Tx,
   ExportTx
-} from "../../src/apis/platformvm"
-import { Output } from "../../src/common"
+} from "avalanche/dist/apis/platformvm"
+import { Output } from "avalanche/dist/common"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults,
   MILLIAVAX
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getBalance.ts
+++ b/examples/platformvm/getBalance.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { PlatformVMAPI } from "../../dist/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getBlockchainStatus.ts
+++ b/examples/platformvm/getBlockchainStatus.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getBlockchains.ts
+++ b/examples/platformvm/getBlockchains.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getCurrentSupply.ts
+++ b/examples/platformvm/getCurrentSupply.ts
@@ -1,5 +1,5 @@
-import { Avalanche, BN } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche, BN } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getCurrentValidators.ts
+++ b/examples/platformvm/getCurrentValidators.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getInterfaces.ts
+++ b/examples/platformvm/getInterfaces.ts
@@ -1,4 +1,4 @@
-import { GetStakeParams } from "../../src/apis/platformvm"
+import { GetStakeParams } from "avalanche/dist/apis/platformvm"
 
 const main = async (): Promise<any> => {
   const getStakeParams: GetStakeParams = {

--- a/examples/platformvm/getPendingValidators.ts
+++ b/examples/platformvm/getPendingValidators.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getRewardUTXOs.ts
+++ b/examples/platformvm/getRewardUTXOs.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { GetRewardUTXOsResponse } from "../../src/apis/platformvm/interfaces"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { GetRewardUTXOsResponse } from "avalanche/dist/apis/platformvm/interfaces"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getStake.ts
+++ b/examples/platformvm/getStake.ts
@@ -1,10 +1,10 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI, KeyChain } from "../../src/apis/platformvm"
-import { GetStakeResponse } from "../../src/apis/platformvm/interfaces"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI, KeyChain } from "avalanche/dist/apis/platformvm"
+import { GetStakeResponse } from "avalanche/dist/apis/platformvm/interfaces"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getStakingAssetID.ts
+++ b/examples/platformvm/getStakingAssetID.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getSubnets.ts
+++ b/examples/platformvm/getSubnets.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getTx.ts
+++ b/examples/platformvm/getTx.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../dist"
-import { PlatformVMAPI } from "../../dist/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getTxStatus.ts
+++ b/examples/platformvm/getTxStatus.ts
@@ -1,5 +1,5 @@
-import { Avalanche } from "../../src"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/getValidatorsAt.ts
+++ b/examples/platformvm/getValidatorsAt.ts
@@ -1,6 +1,6 @@
-import { Avalanche } from "../../src"
-import { GetValidatorsAtResponse } from "../../src/apis/platformvm/interfaces"
-import { PlatformVMAPI } from "../../src/apis/platformvm"
+import { Avalanche } from "avalanche/dist"
+import { GetValidatorsAtResponse } from "avalanche/dist/apis/platformvm/interfaces"
+import { PlatformVMAPI } from "avalanche/dist/apis/platformvm"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/importTx-avax-cchain-create-multisig.ts
+++ b/examples/platformvm/importTx-avax-cchain-create-multisig.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ImportTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/importTx-avax-from-the-xchain-and-create-a-multisig-utxo.ts
+++ b/examples/platformvm/importTx-avax-from-the-xchain-and-create-a-multisig-utxo.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ImportTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/importTx-avax-to-the-P-Chain-from-the-C-Chain-and-consume-a-multisig-atomic-output-and-a-create-multisig-output.ts
+++ b/examples/platformvm/importTx-avax-to-the-P-Chain-from-the-C-Chain-and-consume-a-multisig-atomic-output-and-a-create-multisig-output.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ImportTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/importTx-xchain.ts
+++ b/examples/platformvm/importTx-xchain.ts
@@ -1,4 +1,4 @@
-import { Avalanche, BinTools, BN, Buffer } from "../../src"
+import { Avalanche, BinTools, BN, Buffer } from "avalanche/dist"
 import {
   PlatformVMAPI,
   KeyChain,
@@ -12,12 +12,12 @@ import {
   UnsignedTx,
   Tx,
   ImportTx
-} from "../../src/apis/platformvm"
+} from "avalanche/dist/apis/platformvm"
 import {
   PrivateKeyPrefix,
   DefaultLocalGenesisPrivateKey,
   Defaults
-} from "../../src/utils"
+} from "avalanche/dist/utils"
 
 const ip: string = "localhost"
 const port: number = 9650

--- a/examples/platformvm/subnetAuth.ts
+++ b/examples/platformvm/subnetAuth.ts
@@ -1,5 +1,5 @@
-import { Buffer } from "../../src"
-import { SubnetAuth } from "../../src/apis/platformvm"
+import { Buffer } from "avalanche/dist"
+import { SubnetAuth } from "avalanche/dist/apis/platformvm"
 
 const address1: Buffer = Buffer.alloc(4)
 const address2: Buffer = Buffer.alloc(4)

--- a/examples/pubsub/addAddresses.ts
+++ b/examples/pubsub/addAddresses.ts
@@ -1,4 +1,4 @@
-import { PubSub } from "../../src"
+import { PubSub } from "avalanche/dist"
 
 const main = async (): Promise<any> => {
   const pubsub: PubSub = new PubSub()

--- a/examples/pubsub/newBloom.ts
+++ b/examples/pubsub/newBloom.ts
@@ -1,4 +1,4 @@
-import { PubSub } from "../../src"
+import { PubSub } from "avalanche/dist"
 
 const main = async (): Promise<any> => {
   const pubsub: PubSub = new PubSub()

--- a/examples/pubsub/newSet.ts
+++ b/examples/pubsub/newSet.ts
@@ -1,4 +1,4 @@
-import { PubSub } from "../../src"
+import { PubSub } from "avalanche/dist"
 
 const main = async (): Promise<any> => {
   const pubsub: PubSub = new PubSub()

--- a/examples/socket/newBloom.ts
+++ b/examples/socket/newBloom.ts
@@ -1,4 +1,4 @@
-import { PubSub, Socket } from "../../src"
+import { PubSub, Socket } from "avalanche/dist"
 
 const protocol: string = "ws"
 const host: string = "localhost"

--- a/examples/socket/newSet.ts
+++ b/examples/socket/newSet.ts
@@ -1,4 +1,4 @@
-import { PubSub, Socket } from "../../src"
+import { PubSub, Socket } from "avalanche/dist"
 
 const protocol: string = "ws"
 const host: string = "localhost"


### PR DESCRIPTION
Fixes https://github.com/ava-labs/avalanchejs/issues/551

Imports are now made from avalanche/dist folder

example:

```js
import { Avalanche } from "../../src"
```

->

```js
import { Avalanche } from "avalanche/dist"
```