### PR TITLE
Updated fetch import to fix server error

### DIFF
--- a/src/utils/fetchadapter.ts
+++ b/src/utils/fetchadapter.ts
@@ -1,7 +1,8 @@
 import { AxiosRequestConfig, AxiosResponse, AxiosError } from "axios"
+const f = require('node-fetch');
 
 function createRequest(config: AxiosRequestConfig): Request {
-  const headers = new Headers(config.headers as Record<string, string>)
+  const headers = new f.Headers(config.headers as Record<string, string>)
 
   if (config.auth) {
     const username = config.auth.username || ""
@@ -32,7 +33,7 @@ function createRequest(config: AxiosRequestConfig): Request {
 
   const url = `${fullPath}${params}`
 
-  return new Request(url, options)
+  return new f.Request(url, options)
 }
 
 async function getResponse(request, config): Promise<AxiosResponse> {


### PR DESCRIPTION
I was working with avalanchejs and tried to automate my code using rest api created from express and morgan. When I tried to run it using heroku, it gave reference errors and upon further research, I found a fix and think that it should be put on the package.