### PR TITLE
fix isHex check - previously checking only first character

### DIFF
--- a/src/utils/bintools.ts
+++ b/src/utils/bintools.ts
@@ -92,9 +92,13 @@ export default class BinTools {
     if (hex === "" || hex.trim() === "") {
       return false
     }
+    const startsWith0x = hex.startsWith("0x")
+    const matchResult = startsWith0x
+      ? hex.slice(2).match(/[0-9A-Fa-f]/g)
+      : hex.match(/[0-9A-Fa-f]/g)
     if (
-      (hex.startsWith("0x") && hex.slice(2).match(/^[0-9A-Fa-f]/g)) ||
-      hex.match(/^[0-9A-Fa-f]/g)
+      (startsWith0x && hex.length - 2 == matchResult.length) ||
+      hex.length == matchResult.length
     ) {
       return true
     } else {

--- a/tests/utils/bintools.test.ts
+++ b/tests/utils/bintools.test.ts
@@ -234,11 +234,22 @@ describe("BinTools", (): void => {
       "95eaac2b7a6ee7ad7e597c2f5349b03e461c36c2e1e50fc98a84d01612940bd5"
     const invalidHex1: string =
       "rrrrr.c2b7a6ee7ad7e597c2f5349b03e461c36c2e1e5.fc98a84d016129zzzzz"
-    const invalidHex2: string = ""
+    const invalidHex2: string =
+      "0x95eaac2b7a6ee7ad7e597c2f5349b03e461c36c2e1e50fc98a84d016129zzzz"
+    const invalidHex3: string =
+      "95eaac2b7a6ee7ad7e597c2f5349b03e461c36c2e1e50fc98a84d016129zzzz"
+    const invalidHex4: string =
+      "isGvtnDqETNmmFw7guSJ7mmWhCqboExrpmC8VsWxckHcH9oXb"
+    const invalidHex5: string = ""
+    const invalidHex6: string = "    "
     expect(bintools.isHex(validHex1)).toBe(true)
     expect(bintools.isHex(validHex2)).toBe(true)
     expect(bintools.isHex(invalidHex1)).toBe(false)
     expect(bintools.isHex(invalidHex2)).toBe(false)
+    expect(bintools.isHex(invalidHex3)).toBe(false)
+    expect(bintools.isHex(invalidHex3)).toBe(false)
+    expect(bintools.isHex(invalidHex5)).toBe(false)
+    expect(bintools.isHex(invalidHex6)).toBe(false)
   })
 
   test("stringToAddress", (): void => {


### PR DESCRIPTION
isHex regex was previously checking only the first character of the string is valid hex. Because for many cb58 strings that's also the case the method would return true if the input was cb58 encoded.