### PR TITLE
PlatformVm AddSubnetValidatorTx bug fix

### DIFF
--- a/src/apis/platformvm/tx.ts
+++ b/src/apis/platformvm/tx.ts
@@ -17,6 +17,7 @@ import { SerializedEncoding } from "../../utils/serialization"
 import { AddDelegatorTx, AddValidatorTx } from "./validationtx"
 import { CreateSubnetTx } from "./createsubnettx"
 import { TransactionError } from "../../utils/errors"
+import { AddSubnetValidatorTx } from "./addsubnetvalidatortx"
 
 /**
  * @ignore
@@ -43,6 +44,8 @@ export const SelectTxClass = (txtype: number, ...args: any[]): BaseTx => {
     return new AddValidatorTx(...args)
   } else if (txtype === PlatformVMConstants.CREATESUBNETTX) {
     return new CreateSubnetTx(...args)
+  } else if (txtype === PlatformVMConstants.ADDSUBNETVALIDATORTX) {
+    return new AddSubnetValidatorTx(...args)
   }
   /* istanbul ignore next */
   throw new TransactionError("Error - SelectTxClass: unknown txtype")


### PR DESCRIPTION
I was trying to unserialize AddSubnetValidatorTx but It returns :
`  TransactionError: Error - SelectTxClass: unknown txtype `

In src/apis/platformvm/tx.ts  AddSubnetValidatorTx was missing I added it. 

Now it is working
```
   const bintools = BinTools.getInstance()
    let hex = (await pchain.getTx("DL1itsKyyYFjtW3qTfFFoeh4XD46twfjxYbrGDNdtx5VDdd1P"))   
    const serialization  = Serialization.getInstance()
    const bufTx = serialization.typeToBuffer(hex,"hex")  
    const tx = new Tx()
    tx.fromBuffer(bufTx)
```