### PR TITLE
platform.getBalance JSON RPC now expects an array of addresses instead of a single address string

### DIFF
--- a/src/apis/platformvm/api.ts
+++ b/src/apis/platformvm/api.ts
@@ -479,23 +479,25 @@ export class PlatformVMAPI extends JRPCAPI {
   /**
    * Gets the balance of a particular asset.
    *
-   * @param address The address to pull the asset balance from
+   * @param addresses The addresses to pull the asset balance from
    *
    * @returns Promise with the balance as a {@link https://github.com/indutny/bn.js/|BN} on the provided address.
    */
-  getBalance = async (address: string): Promise<GetBalanceResponse> => {
-    if (typeof this.parseAddress(address) === "undefined") {
-      /* istanbul ignore next */
-      throw new AddressError(
-        "Error - PlatformVMAPI.getBalance: Invalid address format"
-      )
-    }
+  getBalance = async (addresses: string[]): Promise<GetBalanceResponse> => {
+    addresses.forEach(address => {
+      if (typeof this.parseAddress(address) === "undefined") {
+        /* istanbul ignore next */
+        throw new AddressError(
+            "Error - PlatformVMAPI.getBalance: Invalid address format"
+        )
+      }
+    })
     const params: any = {
-      address
+      addresses
     }
     const response: RequestResponseData = await this.callMethod(
-      "platform.getBalance",
-      params
+        "platform.getBalance",
+        params
     )
     return response.data.result
   }

--- a/tests/apis/platformvm/api.test.ts
+++ b/tests/apis/platformvm/api.test.ts
@@ -264,7 +264,7 @@ describe("PlatformVMAPI", (): void => {
         }
       ]
     }
-    const result: Promise<GetBalanceResponse> = api.getBalance(addrA)
+    const result: Promise<GetBalanceResponse> = api.getBalance([addrA])
     const payload: object = {
       result: respobj
     }


### PR DESCRIPTION
update getBalance on the platformVM api package to use `addresses` instead of `address` as a param to the JSON RPC platform.getBalance method

see: https://github.com/ava-labs/avalanchego/releases/tag/v1.9.8