### PR TITLE
Add error handling to examples - Part 1

### DIFF
--- a/examples/admin/alias.ts
+++ b/examples/admin/alias.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const endpoint: string = "/ext/bc/X"
-  const alias: string = "xchain"
-  const successful: boolean = await admin.alias(endpoint, alias)
-  console.log(successful)
+  try {
+    const endpoint: string = "/ext/bc/X"
+    const alias: string = "xchain"
+    const successful: boolean = await admin.alias(endpoint, alias)
+    console.log(successful)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/aliasChain.ts
+++ b/examples/admin/aliasChain.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const blockchain: string = "X"
-  const alias: string = "xchain"
-  const successful: boolean = await admin.aliasChain(blockchain, alias)
-  console.log(successful)
+  try {
+    const blockchain: string = "X"
+    const alias: string = "xchain"
+    const successful: boolean = await admin.aliasChain(blockchain, alias)
+    console.log(successful)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/getChainAliases.ts
+++ b/examples/admin/getChainAliases.ts
@@ -10,9 +10,15 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const blockchain: string = Defaults.network[networkID].X.blockchainID
-  const aliases: string[] = await admin.getChainAliases(blockchain)
-  console.log(aliases)
+  try {
+    const blockchain: string = Defaults.network[networkID].X.blockchainID
+    const aliases: string[] = await admin.getChainAliases(blockchain)
+    console.log(aliases)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/getLoggerLevel.ts
+++ b/examples/admin/getLoggerLevel.ts
@@ -10,11 +10,17 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const loggerName: string = "C"
-  const loggerLevel: GetLoggerLevelResponse = await admin.getLoggerLevel(
-    loggerName
-  )
-  console.log(loggerLevel)
+  try {
+    const loggerName: string = "C"
+    const loggerLevel: GetLoggerLevelResponse = await admin.getLoggerLevel(
+      loggerName
+    )
+    console.log(loggerLevel)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/loadVMs.ts
+++ b/examples/admin/loadVMs.ts
@@ -10,8 +10,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const loggerLevel: LoadVMsResponse = await admin.loadVMs()
-  console.log(loggerLevel)
+  try {
+    const loggerLevel: LoadVMsResponse = await admin.loadVMs()
+    console.log(loggerLevel)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/lockProfile.ts
+++ b/examples/admin/lockProfile.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.lockProfile()
-  console.log(successful)
+  try {
+    const successful: boolean = await admin.lockProfile()
+    console.log(successful)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/memoryProfile.ts
+++ b/examples/admin/memoryProfile.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.memoryProfile()
-  console.log(successful)
+  try {
+    const successful: boolean = await admin.memoryProfile()
+    console.log(successful)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/setLoggerLevel.ts
+++ b/examples/admin/setLoggerLevel.ts
@@ -10,15 +10,21 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const loggerName: string = "C"
-  const logLevel: string = "DEBUG"
-  const displayLevel: string = "INFO"
-  const loggerLevel: SetLoggerLevelResponse = await admin.setLoggerLevel(
-    loggerName,
-    logLevel,
-    displayLevel
-  )
-  console.log(loggerLevel)
+  try {
+    const loggerName: string = "C"
+    const logLevel: string = "DEBUG"
+    const displayLevel: string = "INFO"
+    const loggerLevel: SetLoggerLevelResponse = await admin.setLoggerLevel(
+      loggerName,
+      logLevel,
+      displayLevel
+    )
+    console.log(loggerLevel)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/startCPUProfiler.ts
+++ b/examples/admin/startCPUProfiler.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.startCPUProfiler()
-  console.log(successful)
+  try {
+    const successful: boolean = await admin.startCPUProfiler()
+    console.log(successful)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/admin/stopCPUProfiler.ts
+++ b/examples/admin/stopCPUProfiler.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const admin: AdminAPI = avalanche.Admin()
 
 const main = async (): Promise<any> => {
-  const successful: boolean = await admin.stopCPUProfiler()
-  console.log(successful)
+  try {
+    const successful: boolean = await admin.stopCPUProfiler()
+    console.log(successful)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/auth/changePassword.ts
+++ b/examples/auth/changePassword.ts
@@ -14,20 +14,26 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const auth: AuthAPI = avalanche.Auth()
 
 const main = async (): Promise<any> => {
-  const path: string = "./examples/secrets.json"
-  const encoding: "utf8" = "utf8"
-  const cb = async (err: any, data: any): Promise<void> => {
-    if (err) throw err
-    const jsonData: any = JSON.parse(data)
-    const oldPassword: string = jsonData.oldPassword
-    const newPassword: string = jsonData.newPassword
-    const successful: boolean = await auth.changePassword(
-      oldPassword,
-      newPassword
+  try {
+    const path: string = "./examples/secrets.json"
+    const encoding: "utf8" = "utf8"
+    const cb = async (err: any, data: any): Promise<void> => {
+      if (err) throw err
+      const jsonData: any = JSON.parse(data)
+      const oldPassword: string = jsonData.oldPassword
+      const newPassword: string = jsonData.newPassword
+      const successful: boolean = await auth.changePassword(
+        oldPassword,
+        newPassword
+      )
+      console.log(successful)
+    }
+    readFile(path, encoding, cb)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
     )
-    console.log(successful)
   }
-  readFile(path, encoding, cb)
 }
 
 main()

--- a/examples/auth/newToken.ts
+++ b/examples/auth/newToken.ts
@@ -15,20 +15,26 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const auth: AuthAPI = avalanche.Auth()
 
 const main = async (): Promise<any> => {
-  const path: string = "./examples/secrets.json"
-  const encoding: "utf8" = "utf8"
-  const cb = async (err: any, data: any): Promise<void> => {
-    if (err) throw err
-    const jsonData: any = JSON.parse(data)
-    const password: string = jsonData.password
-    const endpoints: string[] = ["*"]
-    const token: string | ErrorResponseObject = await auth.newToken(
-      password,
-      endpoints
+  try {
+    const path: string = "./examples/secrets.json"
+    const encoding: "utf8" = "utf8"
+    const cb = async (err: any, data: any): Promise<void> => {
+      if (err) throw err
+      const jsonData: any = JSON.parse(data)
+      const password: string = jsonData.password
+      const endpoints: string[] = ["*"]
+      const token: string | ErrorResponseObject = await auth.newToken(
+        password,
+        endpoints
+      )
+      console.log(token)
+    }
+    readFile(path, encoding, cb)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
     )
-    console.log(token)
   }
-  readFile(path, encoding, cb)
 }
 
 main()

--- a/examples/auth/revokeToken.ts
+++ b/examples/auth/revokeToken.ts
@@ -14,17 +14,23 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const auth: AuthAPI = avalanche.Auth()
 
 const main = async (): Promise<any> => {
-  const path: string = "./examples/secrets.json"
-  const encoding: "utf8" = "utf8"
-  const cb = async (err: any, data: any): Promise<void> => {
-    if (err) throw err
-    const jsonData: any = JSON.parse(data)
-    const password: string = jsonData.password
-    const token: string = jsonData.token
-    const successful: boolean = await auth.revokeToken(password, token)
-    console.log(successful)
+  try {
+    const path: string = "./examples/secrets.json"
+    const encoding: "utf8" = "utf8"
+    const cb = async (err: any, data: any): Promise<void> => {
+      if (err) throw err
+      const jsonData: any = JSON.parse(data)
+      const password: string = jsonData.password
+      const token: string = jsonData.token
+      const successful: boolean = await auth.revokeToken(password, token)
+      console.log(successful)
+    }
+    readFile(path, encoding, cb)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
   }
-  readFile(path, encoding, cb)
 }
 
 main()

--- a/examples/avm/JSONXChainTx.ts
+++ b/examples/avm/JSONXChainTx.ts
@@ -9,15 +9,21 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const txID: string = "2fJer7o3HpPYxqyHXo23G4HoPvfEqcUXYojMULi2mbBEoBFqoM"
-  const hex = (await xchain.getTx(txID)) as string
-  const buf: Buffer = new Buffer(hex.slice(2), "hex")
-  const tx: Tx = new Tx()
-  tx.fromBuffer(buf)
-  const jsonStr: string = JSON.stringify(tx)
-  console.log(jsonStr)
-  const jsn: Object = JSON.parse(jsonStr)
-  console.log(jsn)
+  try {
+    const txID: string = "2fJer7o3HpPYxqyHXo23G4HoPvfEqcUXYojMULi2mbBEoBFqoM"
+    const hex = (await xchain.getTx(txID)) as string
+    const buf: Buffer = new Buffer(hex.slice(2), "hex")
+    const tx: Tx = new Tx()
+    tx.fromBuffer(buf)
+    const jsonStr: string = JSON.stringify(tx)
+    console.log(jsonStr)
+    const jsn: Object = JSON.parse(jsonStr)
+    console.log(jsn)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/addressFromBuffer.ts
+++ b/examples/avm/addressFromBuffer.ts
@@ -22,23 +22,29 @@ const avalanche: Avalanche = new Avalanche(
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const utxoset: UTXOSet = new UTXOSet()
-  utxoset.addArray([
-    "11Zf8cc55Qy1rVgy3t87MJVCSEu539whRSwpdbrtHS6oh5Hnwv1gz8G3BtLJ73MPspLkD93cygZufT4TPYZCmuxW5cRdPrVMbZAHfb6uyGM1jNGBhBiQAgQ6V1yceYf825g27TT6WU4bTdbniWdECDWdGdi84hdiqSJH2y",
-    "11Zf8cc55Qy1rVgy3t87MJVCSEu539whRSwpdbrtHS6oh5Hnwv1NjNhqZnievVs2kBD9qTrayBYRs91emGTtmnu2wzqpLstbAPJDdVjf3kjwGWywNCdjV6TPGojVR5vHpJhBVRtHTQXR9VP9MBdHXge8zEBsQJAoZhTbr2"
-  ])
-  const utxos: UTXO[] = utxoset.getAllUTXOs()
+  try {
+    const utxoset: UTXOSet = new UTXOSet()
+    utxoset.addArray([
+      "11Zf8cc55Qy1rVgy3t87MJVCSEu539whRSwpdbrtHS6oh5Hnwv1gz8G3BtLJ73MPspLkD93cygZufT4TPYZCmuxW5cRdPrVMbZAHfb6uyGM1jNGBhBiQAgQ6V1yceYf825g27TT6WU4bTdbniWdECDWdGdi84hdiqSJH2y",
+      "11Zf8cc55Qy1rVgy3t87MJVCSEu539whRSwpdbrtHS6oh5Hnwv1NjNhqZnievVs2kBD9qTrayBYRs91emGTtmnu2wzqpLstbAPJDdVjf3kjwGWywNCdjV6TPGojVR5vHpJhBVRtHTQXR9VP9MBdHXge8zEBsQJAoZhTbr2"
+    ])
+    const utxos: UTXO[] = utxoset.getAllUTXOs()
 
-  utxos.map((utxo: UTXO): void => {
-    const output: Output = utxo.getOutput()
-    const addresses: string[] = output
-      .getAddresses()
-      .map((x: Buffer): string => {
-        const addy: string = xchain.addressFromBuffer(x)
-        return addy
-      })
-    console.log(addresses)
-  })
+    utxos.map((utxo: UTXO): void => {
+      const output: Output = utxo.getOutput()
+      const addresses: string[] = output
+        .getAddresses()
+        .map((x: Buffer): string => {
+          const addy: string = xchain.addressFromBuffer(x)
+          return addy
+        })
+      console.log(addresses)
+    })
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/baseEndpoint.ts
+++ b/examples/avm/baseEndpoint.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 avalanche.setAddress(ip, port, protocol, baseEndpoint)
 
 const main = async (): Promise<any> => {
-  const baseEndpoint: string = avalanche.getBaseEndpoint()
-  console.log(baseEndpoint)
+  try {
+    const baseEndpoint: string = avalanche.getBaseEndpoint()
+    console.log(baseEndpoint)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/baseTx-ant.ts
+++ b/examples/avm/baseTx-ant.ts
@@ -44,87 +44,97 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX and ANT")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO): void => {
-    const typeID: number = utxo.getOutput().getTypeID()
-    if (typeID != 6) {
-      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-      const amt: BN = amountOutput.getAmount().clone()
-      const txID: Buffer = utxo.getTxID()
-      const outputIDX: Buffer = utxo.getOutputIdx()
-      const assetID: Buffer = utxo.getAssetID()
+  try {
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO): void => {
+      const typeID: number = utxo.getOutput().getTypeID()
+      if (typeID != 6) {
+        const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+        const amt: BN = amountOutput.getAmount().clone()
+        const txID: Buffer = utxo.getTxID()
+        const outputIDX: Buffer = utxo.getOutputIdx()
+        const assetID: Buffer = utxo.getAssetID()
 
-      if (assetID.toString("hex") === avaxAssetIDBuf.toString("hex")) {
-        const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-          amt.sub(fee),
-          xAddresses,
-          locktime,
-          threshold
-        )
-        // Uncomment for codecID 00 01
-        // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(
-          avaxAssetIDBuf,
-          secpTransferOutput
-        )
-        outputs.push(transferableOutput)
+        if (assetID.toString("hex") === avaxAssetIDBuf.toString("hex")) {
+          const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+            amt.sub(fee),
+            xAddresses,
+            locktime,
+            threshold
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferOutput.setCodecID(codecID)
+          const transferableOutput: TransferableOutput = new TransferableOutput(
+            avaxAssetIDBuf,
+            secpTransferOutput
+          )
+          outputs.push(transferableOutput)
 
-        const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-        // Uncomment for codecID 00 01
-        // secpTransferInput.setCodecID(codecID)
-        secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(
-          txID,
-          outputIDX,
-          avaxAssetIDBuf,
-          secpTransferInput
-        )
-        inputs.push(input)
-      } else {
-        const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-          amt,
-          xAddresses,
-          locktime,
-          threshold
-        )
-        // Uncomment for codecID 00 01
-        // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(
-          assetID,
-          secpTransferOutput
-        )
-        outputs.push(transferableOutput)
+          const secpTransferInput: SECPTransferInput = new SECPTransferInput(
+            amt
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferInput.setCodecID(codecID)
+          secpTransferInput.addSignatureIdx(0, xAddresses[0])
+          const input: TransferableInput = new TransferableInput(
+            txID,
+            outputIDX,
+            avaxAssetIDBuf,
+            secpTransferInput
+          )
+          inputs.push(input)
+        } else {
+          const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+            amt,
+            xAddresses,
+            locktime,
+            threshold
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferOutput.setCodecID(codecID)
+          const transferableOutput: TransferableOutput = new TransferableOutput(
+            assetID,
+            secpTransferOutput
+          )
+          outputs.push(transferableOutput)
 
-        const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-        // Uncomment for codecID 00 01
-        // secpTransferInput.setCodecID(codecID)
-        secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(
-          txID,
-          outputIDX,
-          assetID,
-          secpTransferInput
-        )
-        inputs.push(input)
+          const secpTransferInput: SECPTransferInput = new SECPTransferInput(
+            amt
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferInput.setCodecID(codecID)
+          secpTransferInput.addSignatureIdx(0, xAddresses[0])
+          const input: TransferableInput = new TransferableInput(
+            txID,
+            outputIDX,
+            assetID,
+            secpTransferInput
+          )
+          inputs.push(input)
+        }
       }
-    }
-  })
+    })
 
-  const baseTx: BaseTx = new BaseTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo
-  )
-  // Uncomment for codecID 00 01
-  // baseTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const baseTx: BaseTx = new BaseTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo
+    )
+    // Uncomment for codecID 00 01
+    // baseTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/baseTx-avax-create-multisig.ts
+++ b/examples/avm/baseTx-avax-create-multisig.ts
@@ -55,60 +55,67 @@ const memo: Buffer = Buffer.from(
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  //   secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  outputs.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO): void => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    // Uncomment for codecID 00 01
-    // secpTransferInput.setCodecID(codecID)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
-
-    const input: TransferableInput = new TransferableInput(
-      txid,
-      outputidx,
-      avaxAssetIDBuf,
-      secpTransferInput
+  try {
+    const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
     )
-    inputs.push(input)
-  })
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      xAddresses,
+      locktime,
+      threshold
+    )
+    // Uncomment for codecID 00 01
+    //   secpTransferOutput.setCodecID(codecID)
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    outputs.push(transferableOutput)
 
-  const baseTx: BaseTx = new BaseTx(
-    networkID,
-    xBlockchainIDBuf,
-    outputs,
-    inputs,
-    memo
-  )
-  // Uncomment for codecID 00 01
-  // baseTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO): void => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amt: BN = amountOutput.getAmount().clone()
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
+
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      // Uncomment for codecID 00 01
+      // secpTransferInput.setCodecID(codecID)
+      secpTransferInput.addSignatureIdx(0, xAddresses[0])
+
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
+    })
+
+    const baseTx: BaseTx = new BaseTx(
+      networkID,
+      xBlockchainIDBuf,
+      outputs,
+      inputs,
+      memo
+    )
+    // Uncomment for codecID 00 01
+    // baseTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
+
 main()

--- a/examples/avm/baseTx-avax-send-multisig.ts
+++ b/examples/avm/baseTx-avax-send-multisig.ts
@@ -60,65 +60,71 @@ const memo: Buffer = Buffer.from(
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    [xAddresses[0]],
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  //   secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  outputs.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO): void => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      [xAddresses[0]],
+      locktime,
+      threshold
+    )
     // Uncomment for codecID 00 01
-    // secpTransferInput.setCodecID(codecID)
-    xAddresses.forEach((xAddress: Buffer, index: number): void => {
-      if (index < 3) {
-        secpTransferInput.addSignatureIdx(index, xAddress)
-      }
+    //   secpTransferOutput.setCodecID(codecID)
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    outputs.push(transferableOutput)
+
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO): void => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amt: BN = amountOutput.getAmount().clone()
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
+
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      // Uncomment for codecID 00 01
+      // secpTransferInput.setCodecID(codecID)
+      xAddresses.forEach((xAddress: Buffer, index: number): void => {
+        if (index < 3) {
+          secpTransferInput.addSignatureIdx(index, xAddress)
+        }
+      })
+
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
     })
 
-    const input: TransferableInput = new TransferableInput(
-      txid,
-      outputidx,
-      avaxAssetIDBuf,
-      secpTransferInput
+    const baseTx: BaseTx = new BaseTx(
+      networkID,
+      xBlockchainIDBuf,
+      outputs,
+      inputs,
+      memo
     )
-    inputs.push(input)
-  })
-
-  const baseTx: BaseTx = new BaseTx(
-    networkID,
-    xBlockchainIDBuf,
-    outputs,
-    inputs,
-    memo
-  )
-  // Uncomment for codecID 00 01
-  //   baseTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    // Uncomment for codecID 00 01
+    //   baseTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/baseTx-avax.ts
+++ b/examples/avm/baseTx-avax.ts
@@ -46,79 +46,85 @@ const memo: Buffer = Buffer.from("AVM manual BaseTx to send AVAX")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  outputs.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    // Uncomment for codecID 00 01
-    // secpTransferInput.setCodecID(codecID)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
-
-    const input: TransferableInput = new TransferableInput(
-      txid,
-      outputidx,
-      avaxAssetIDBuf,
-      secpTransferInput
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
     )
-    inputs.push(input)
-  })
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      xAddresses,
+      locktime,
+      threshold
+    )
+    // Uncomment for codecID 00 01
+    // secpTransferOutput.setCodecID(codecID)
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    outputs.push(transferableOutput)
 
-  const baseTx: BaseTx = new BaseTx(
-    networkID,
-    bintools.cb58Decode(xBlockchainID),
-    outputs,
-    inputs,
-    memo
-  )
-  // Uncomment for codecID 00 01
-  // baseTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txBuf: Buffer = tx.toBuffer()
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO) => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amt: BN = amountOutput.getAmount().clone()
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
 
-  // Start example script for generating the TxID in
-  // advance of issuing the tx to a full node
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      // Uncomment for codecID 00 01
+      // secpTransferInput.setCodecID(codecID)
+      secpTransferInput.addSignatureIdx(0, xAddresses[0])
 
-  // Create sha256 hash of the tx buffer
-  const sha256Hash: Buffer = Buffer.from(
-    createHash("sha256").update(txBuf).digest().buffer
-  )
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
+    })
 
-  // cb58 the sha256 hash
-  const generatedTxID: string = bintools.cb58Encode(sha256Hash)
-  console.log(`Generated TXID: ${generatedTxID}`)
+    const baseTx: BaseTx = new BaseTx(
+      networkID,
+      bintools.cb58Decode(xBlockchainID),
+      outputs,
+      inputs,
+      memo
+    )
+    // Uncomment for codecID 00 01
+    // baseTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(baseTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txBuf: Buffer = tx.toBuffer()
 
-  // End example script for generating the TxID in
-  // advance of issuing the tx to a full node
+    // Start example script for generating the TxID in
+    // advance of issuing the tx to a full node
 
-  // get the actual txID from the full node
-  const actualTxID: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${actualTxID}`)
+    // Create sha256 hash of the tx buffer
+    const sha256Hash: Buffer = Buffer.from(
+      createHash("sha256").update(txBuf).digest().buffer
+    )
+
+    // cb58 the sha256 hash
+    const generatedTxID: string = bintools.cb58Encode(sha256Hash)
+    console.log(`Generated TXID: ${generatedTxID}`)
+
+    // End example script for generating the TxID in
+    // advance of issuing the tx to a full node
+
+    // get the actual txID from the full node
+    const actualTxID: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${actualTxID}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildBaseTx-ant.ts
+++ b/examples/avm/buildBaseTx-ant.ts
@@ -31,30 +31,36 @@ const memo: Buffer = Buffer.from(
 )
 
 const main = async (): Promise<any> => {
-  const amount: BN = new BN(5)
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const assetID: string = "KD4byR998qmVivF2zmrhLb6gjwKGSB5xCerV2nYXb4XNXVGEP"
-  const toAddresses: string[] = [xAddressStrings[0]]
+  try {
+    const amount: BN = new BN(5)
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const assetID: string = "KD4byR998qmVivF2zmrhLb6gjwKGSB5xCerV2nYXb4XNXVGEP"
+    const toAddresses: string[] = [xAddressStrings[0]]
 
-  const unsignedTx: UnsignedTx = await xchain.buildBaseTx(
-    utxoSet,
-    amount,
-    assetID,
-    toAddresses,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime,
-    threshold
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildBaseTx(
+      utxoSet,
+      amount,
+      assetID,
+      toAddresses,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime,
+      threshold
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildBaseTx-avax.ts
+++ b/examples/avm/buildBaseTx-avax.ts
@@ -42,33 +42,39 @@ const memo: Buffer = Buffer.from("AVM utility method buildBaseTx to send AVAX")
 const fee: BN = xchain.getDefaultTxFee()
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const amount: BN = balance.sub(fee)
+  try {
+    const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const amount: BN = balance.sub(fee)
 
-  const unsignedTx: UnsignedTx = await xchain.buildBaseTx(
-    utxoSet,
-    amount,
-    avaxAssetID,
-    xAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime,
-    threshold
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildBaseTx(
+      utxoSet,
+      amount,
+      avaxAssetID,
+      xAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime,
+      threshold
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildCreateAssetTx.ts
+++ b/examples/avm/buildCreateAssetTx.ts
@@ -37,42 +37,48 @@ const symbol: string = "TEST"
 const denomination: number = 3
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
 
-  const amount: BN = new BN(507)
-  const vcapSecpOutput = new SECPTransferOutput(
-    amount,
-    xAddresses,
-    locktime,
-    threshold
-  )
-  const initialStates: InitialStates = new InitialStates()
-  initialStates.addOutput(vcapSecpOutput)
+    const amount: BN = new BN(507)
+    const vcapSecpOutput = new SECPTransferOutput(
+      amount,
+      xAddresses,
+      locktime,
+      threshold
+    )
+    const initialStates: InitialStates = new InitialStates()
+    initialStates.addOutput(vcapSecpOutput)
 
-  const secpMintOutput: SECPMintOutput = new SECPMintOutput(
-    xAddresses,
-    locktime,
-    threshold
-  )
-  outputs.push(secpMintOutput)
+    const secpMintOutput: SECPMintOutput = new SECPMintOutput(
+      xAddresses,
+      locktime,
+      threshold
+    )
+    outputs.push(secpMintOutput)
 
-  const unsignedTx: UnsignedTx = await xchain.buildCreateAssetTx(
-    utxoSet,
-    xAddressStrings,
-    xAddressStrings,
-    initialStates,
-    name,
-    symbol,
-    denomination,
-    outputs,
-    memo
-  )
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const unsignedTx: UnsignedTx = await xchain.buildCreateAssetTx(
+      utxoSet,
+      xAddressStrings,
+      xAddressStrings,
+      initialStates,
+      name,
+      symbol,
+      denomination,
+      outputs,
+      memo
+    )
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildCreateNFTAssetTx.ts
+++ b/examples/avm/buildCreateNFTAssetTx.ts
@@ -35,26 +35,32 @@ const name: string = "non fungible token"
 const symbol: string = "NFT"
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const minterSets: MinterSet[] = [new MinterSet(threshold, xAddresses)]
-  const unsignedTx: UnsignedTx = await xchain.buildCreateNFTAssetTx(
-    utxoSet,
-    xAddressStrings,
-    xAddressStrings,
-    minterSets,
-    name,
-    symbol,
-    memo,
-    asOf,
-    locktime
-  )
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const minterSets: MinterSet[] = [new MinterSet(threshold, xAddresses)]
+    const unsignedTx: UnsignedTx = await xchain.buildCreateNFTAssetTx(
+      utxoSet,
+      xAddressStrings,
+      xAddressStrings,
+      minterSets,
+      name,
+      symbol,
+      memo,
+      asOf,
+      locktime
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildCreateNFTMintTx.ts
+++ b/examples/avm/buildCreateNFTMintTx.ts
@@ -61,52 +61,58 @@ const payload: Buffer = Buffer.from("NFT Payload")
 const asOf: BN = UnixNow()
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const outputOwners: OutputOwners = new OutputOwners(
-    xAddresses,
-    locktime,
-    threshold
-  )
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  let txid: Buffer = Buffer.from(
-    "2fSX8P4vhGNZsD3WELwwTxx4XzCNwicyFiYbp3Q965BMgJ8g9"
-  )
-  let assetID: Buffer = Buffer.from(
-    "2fSX8P4vhGNZsD3WELwwTxx4XzCNwicyFiYbp3Q965BMgJ8g9"
-  )
-  utxos.forEach((utxo: UTXO): void => {
-    if (utxo.getOutput().getTypeID() === 10) {
-      txid = utxo.getTxID()
-      assetID = utxo.getAssetID()
-    }
-  })
-  const nftMintOutputUTXOIDs: string[] = getUTXOIDs(
-    utxoSet,
-    bintools.cb58Encode(txid),
-    AVMConstants.NFTMINTOUTPUTID,
-    bintools.cb58Encode(assetID)
-  )
-  const nftMintOutputUTXOID: string = nftMintOutputUTXOIDs[0]
-  const groupID: number = 0
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const outputOwners: OutputOwners = new OutputOwners(
+      xAddresses,
+      locktime,
+      threshold
+    )
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    let txid: Buffer = Buffer.from(
+      "2fSX8P4vhGNZsD3WELwwTxx4XzCNwicyFiYbp3Q965BMgJ8g9"
+    )
+    let assetID: Buffer = Buffer.from(
+      "2fSX8P4vhGNZsD3WELwwTxx4XzCNwicyFiYbp3Q965BMgJ8g9"
+    )
+    utxos.forEach((utxo: UTXO): void => {
+      if (utxo.getOutput().getTypeID() === 10) {
+        txid = utxo.getTxID()
+        assetID = utxo.getAssetID()
+      }
+    })
+    const nftMintOutputUTXOIDs: string[] = getUTXOIDs(
+      utxoSet,
+      bintools.cb58Encode(txid),
+      AVMConstants.NFTMINTOUTPUTID,
+      bintools.cb58Encode(assetID)
+    )
+    const nftMintOutputUTXOID: string = nftMintOutputUTXOIDs[0]
+    const groupID: number = 0
 
-  const unsignedTx: UnsignedTx = await xchain.buildCreateNFTMintTx(
-    utxoSet,
-    outputOwners,
-    xAddressStrings,
-    xAddressStrings,
-    nftMintOutputUTXOID,
-    groupID,
-    payload,
-    memo,
-    asOf
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildCreateNFTMintTx(
+      utxoSet,
+      outputOwners,
+      xAddressStrings,
+      xAddressStrings,
+      nftMintOutputUTXOID,
+      groupID,
+      payload,
+      memo,
+      asOf
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const id: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${id}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const id: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${id}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildExportTx-PChain.ts
+++ b/examples/avm/buildExportTx-PChain.ts
@@ -45,32 +45,38 @@ const memo: Buffer = Buffer.from(
 const fee: BN = xchain.getDefaultTxFee()
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const amount: BN = balance.sub(fee)
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const amount: BN = balance.sub(fee)
 
-  const unsignedTx: UnsignedTx = await xchain.buildExportTx(
-    utxoSet,
-    amount,
-    pChainBlockchainID,
-    pAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildExportTx(
+      utxoSet,
+      amount,
+      pChainBlockchainID,
+      pAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildExportTx-cchain-ant.ts
+++ b/examples/avm/buildExportTx-cchain-ant.ts
@@ -37,31 +37,37 @@ const memo: Buffer = Buffer.from(
 )
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const amount: BN = new BN(350)
-  const threshold: number = 1
-  const assetID: string = "Ycg5QzddNwe3ebfFXhoGUDnWgC6GE88QRakRnn9dp3nGwqCwD"
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const amount: BN = new BN(350)
+    const threshold: number = 1
+    const assetID: string = "Ycg5QzddNwe3ebfFXhoGUDnWgC6GE88QRakRnn9dp3nGwqCwD"
 
-  const unsignedTx: UnsignedTx = await xchain.buildExportTx(
-    utxoSet,
-    amount,
-    cChainBlockchainID,
-    cAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime,
-    threshold,
-    assetID
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildExportTx(
+      utxoSet,
+      amount,
+      cChainBlockchainID,
+      cAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime,
+      threshold,
+      assetID
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildExportTx-cchain-avax.ts
+++ b/examples/avm/buildExportTx-cchain-avax.ts
@@ -42,32 +42,38 @@ const memo: Buffer = Buffer.from(
 const fee: BN = xchain.getDefaultTxFee()
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const amount: BN = balance.sub(fee)
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const getBalanceResponse: GetBalanceResponse = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const amount: BN = balance.sub(fee)
 
-  const unsignedTx: UnsignedTx = await xchain.buildExportTx(
-    utxoSet,
-    amount,
-    cChainBlockchainID,
-    cAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildExportTx(
+      utxoSet,
+      amount,
+      cChainBlockchainID,
+      cAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildImportTx-PChain.ts
+++ b/examples/avm/buildImportTx-PChain.ts
@@ -33,27 +33,33 @@ const memo: Buffer = Buffer.from(
 )
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings,
-    pChainBlockchainID
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings,
+      pChainBlockchainID
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
 
-  const unsignedTx: UnsignedTx = await xchain.buildImportTx(
-    utxoSet,
-    xAddressStrings,
-    pChainBlockchainID,
-    xAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime,
-    threshold
-  )
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const unsignedTx: UnsignedTx = await xchain.buildImportTx(
+      utxoSet,
+      xAddressStrings,
+      pChainBlockchainID,
+      xAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime,
+      threshold
+    )
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildImportTx-cchain.ts
+++ b/examples/avm/buildImportTx-cchain.ts
@@ -33,27 +33,33 @@ const memo: Buffer = Buffer.from(
 )
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings,
-    cChainBlockchainID
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings,
+      cChainBlockchainID
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
 
-  const unsignedTx: UnsignedTx = await xchain.buildImportTx(
-    utxoSet,
-    xAddressStrings,
-    cChainBlockchainID,
-    xAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime,
-    threshold
-  )
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const unsignedTx: UnsignedTx = await xchain.buildImportTx(
+      utxoSet,
+      xAddressStrings,
+      cChainBlockchainID,
+      xAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime,
+      threshold
+    )
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildNFTTransferTx.ts
+++ b/examples/avm/buildNFTTransferTx.ts
@@ -55,42 +55,48 @@ const memo: Buffer = Buffer.from(
 const asOf: BN = UnixNow()
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  let txid: Buffer = Buffer.from("")
-  let assetID: Buffer = Buffer.from("")
-  utxos.forEach((utxo: UTXO) => {
-    if (utxo.getOutput().getTypeID() === 11) {
-      txid = utxo.getTxID()
-      assetID = utxo.getAssetID()
-    }
-  })
-  const nftTransferOutputUTXOIDs: string[] = getUTXOIDs(
-    utxoSet,
-    bintools.cb58Encode(txid),
-    AVMConstants.NFTXFEROUTPUTID,
-    bintools.cb58Encode(assetID)
-  )
-  const nftTransferOutputUTXOID: string = nftTransferOutputUTXOIDs[0]
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    let txid: Buffer = Buffer.from("")
+    let assetID: Buffer = Buffer.from("")
+    utxos.forEach((utxo: UTXO) => {
+      if (utxo.getOutput().getTypeID() === 11) {
+        txid = utxo.getTxID()
+        assetID = utxo.getAssetID()
+      }
+    })
+    const nftTransferOutputUTXOIDs: string[] = getUTXOIDs(
+      utxoSet,
+      bintools.cb58Encode(txid),
+      AVMConstants.NFTXFEROUTPUTID,
+      bintools.cb58Encode(assetID)
+    )
+    const nftTransferOutputUTXOID: string = nftTransferOutputUTXOIDs[0]
 
-  const unsignedTx: UnsignedTx = await xchain.buildNFTTransferTx(
-    utxoSet,
-    xAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    nftTransferOutputUTXOID,
-    memo,
-    asOf,
-    locktime,
-    threshold
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildNFTTransferTx(
+      utxoSet,
+      xAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      nftTransferOutputUTXOID,
+      memo,
+      asOf,
+      locktime,
+      threshold
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const id: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${id}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const id: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${id}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/buildSECPMintTx.ts
+++ b/examples/avm/buildSECPMintTx.ts
@@ -62,53 +62,59 @@ const memo: Buffer = Buffer.from(
 const asOf: BN = UnixNow()
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
-    xAddressStrings
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  let mintUTXOID: string = ""
-  let mintOwner: SECPMintOutput = new SECPMintOutput()
-  let secpTransferOutput: SECPTransferOutput = new SECPTransferOutput()
-  let txid: Buffer = Buffer.from("")
-  let assetID: Buffer = Buffer.from("")
-  utxos.forEach((utxo: UTXO) => {
-    if (utxo.getOutput().getTypeID() === 6) {
-      txid = utxo.getTxID()
-      assetID = utxo.getAssetID()
-    }
-  })
-  const secpMintOutputUTXOIDs: string[] = getUTXOIDs(
-    utxoSet,
-    bintools.cb58Encode(txid),
-    AVMConstants.SECPMINTOUTPUTID,
-    bintools.cb58Encode(assetID)
-  )
-  mintUTXOID = secpMintOutputUTXOIDs[0]
-  const utxo: UTXO = utxoSet.getUTXO(secpMintOutputUTXOIDs[0])
-  mintOwner = utxo.getOutput() as SECPMintOutput
-  const amount: BN = new BN(54321)
-  secpTransferOutput = new SECPTransferOutput(
-    amount,
-    xAddresses,
-    locktime,
-    threshold
-  )
+  try {
+    const avmUTXOResponse: GetUTXOsResponse = await xchain.getUTXOs(
+      xAddressStrings
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    let mintUTXOID: string = ""
+    let mintOwner: SECPMintOutput = new SECPMintOutput()
+    let secpTransferOutput: SECPTransferOutput = new SECPTransferOutput()
+    let txid: Buffer = Buffer.from("")
+    let assetID: Buffer = Buffer.from("")
+    utxos.forEach((utxo: UTXO) => {
+      if (utxo.getOutput().getTypeID() === 6) {
+        txid = utxo.getTxID()
+        assetID = utxo.getAssetID()
+      }
+    })
+    const secpMintOutputUTXOIDs: string[] = getUTXOIDs(
+      utxoSet,
+      bintools.cb58Encode(txid),
+      AVMConstants.SECPMINTOUTPUTID,
+      bintools.cb58Encode(assetID)
+    )
+    mintUTXOID = secpMintOutputUTXOIDs[0]
+    const utxo: UTXO = utxoSet.getUTXO(secpMintOutputUTXOIDs[0])
+    mintOwner = utxo.getOutput() as SECPMintOutput
+    const amount: BN = new BN(54321)
+    secpTransferOutput = new SECPTransferOutput(
+      amount,
+      xAddresses,
+      locktime,
+      threshold
+    )
 
-  const unsignedTx: UnsignedTx = await xchain.buildSECPMintTx(
-    utxoSet,
-    mintOwner,
-    secpTransferOutput,
-    xAddressStrings,
-    xAddressStrings,
-    mintUTXOID,
-    memo,
-    asOf
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildSECPMintTx(
+      utxoSet,
+      mintOwner,
+      secpTransferOutput,
+      xAddressStrings,
+      xAddressStrings,
+      mintUTXOID,
+      memo,
+      asOf
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const id: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${id}`)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const id: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${id}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/createAddress.ts
+++ b/examples/avm/createAddress.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const username: string = "username"
-  const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const address: string = await xchain.createAddress(username, password)
-  console.log(address)
+  try {
+    const username: string = "username"
+    const password: string = "Vz48jjHLTCcAepH95nT4B"
+    const address: string = await xchain.createAddress(username, password)
+    console.log(address)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/createAssetTx-ant.ts
+++ b/examples/avm/createAssetTx-ant.ts
@@ -49,86 +49,92 @@ const denomination: number = 3
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  outputs.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    // Uncomment for codecID 00 01
-    // secpTransferInput.setCodecID(codecID)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
-
-    const input: TransferableInput = new TransferableInput(
-      txid,
-      outputidx,
-      avaxAssetIDBuf,
-      secpTransferInput
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
     )
-    inputs.push(input)
-  })
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      xAddresses,
+      locktime,
+      threshold
+    )
+    // Uncomment for codecID 00 01
+    // secpTransferOutput.setCodecID(codecID)
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    outputs.push(transferableOutput)
 
-  const amount: BN = new BN(507)
-  const vcapSecpOutput = new SECPTransferOutput(
-    amount,
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  // vcapSecpOutput.setCodecID(codecID)
-  const secpMintOutput: SECPMintOutput = new SECPMintOutput(
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  // secpMintOutput.setCodecID(codecID)
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO) => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amt: BN = amountOutput.getAmount().clone()
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
 
-  const initialStates: InitialStates = new InitialStates()
-  initialStates.addOutput(vcapSecpOutput)
-  initialStates.addOutput(secpMintOutput)
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      // Uncomment for codecID 00 01
+      // secpTransferInput.setCodecID(codecID)
+      secpTransferInput.addSignatureIdx(0, xAddresses[0])
 
-  const createAssetTx: CreateAssetTx = new CreateAssetTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo,
-    name,
-    symbol,
-    denomination,
-    initialStates
-  )
-  // Uncomment for codecID 00 01
-  // createAssetTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(createAssetTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
+    })
+
+    const amount: BN = new BN(507)
+    const vcapSecpOutput = new SECPTransferOutput(
+      amount,
+      xAddresses,
+      locktime,
+      threshold
+    )
+    // Uncomment for codecID 00 01
+    // vcapSecpOutput.setCodecID(codecID)
+    const secpMintOutput: SECPMintOutput = new SECPMintOutput(
+      xAddresses,
+      locktime,
+      threshold
+    )
+    // Uncomment for codecID 00 01
+    // secpMintOutput.setCodecID(codecID)
+
+    const initialStates: InitialStates = new InitialStates()
+    initialStates.addOutput(vcapSecpOutput)
+    initialStates.addOutput(secpMintOutput)
+
+    const createAssetTx: CreateAssetTx = new CreateAssetTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo,
+      name,
+      symbol,
+      denomination,
+      initialStates
+    )
+    // Uncomment for codecID 00 01
+    // createAssetTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(createAssetTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/createAssetTx-nft.ts
+++ b/examples/avm/createAssetTx-nft.ts
@@ -52,86 +52,92 @@ const groupID: number = 0
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  //   secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  outputs.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO): void => {
-    const outputID: number = utxo.getOutput().getTypeID()
-    const assetID: Buffer = utxo.getAssetID()
-    if (
-      outputID === 7 &&
-      assetID.toString("hex") === avaxAssetIDBuf.toString("hex")
-    ) {
-      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-      const amt: BN = amountOutput.getAmount().clone()
-      const txid: Buffer = utxo.getTxID()
-      const outputidx: Buffer = utxo.getOutputIdx()
-
-      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-      // Uncomment for codecID 00 01
-      // secpTransferInput.setCodecID(codecID)
-      secpTransferInput.addSignatureIdx(0, xAddresses[0])
-
-      const input: TransferableInput = new TransferableInput(
-        txid,
-        outputidx,
-        avaxAssetIDBuf,
-        secpTransferInput
-      )
-      inputs.push(input)
-    }
-  })
-
-  const initialStates: InitialStates = new InitialStates()
-  const minterSets: MinterSet[] = [new MinterSet(threshold, xAddresses)]
-  for (let i: number = 0; i <= 5; i++) {
-    const nftMintOutput: NFTMintOutput = new NFTMintOutput(
-      groupID,
-      minterSets[0].getMinters(),
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      xAddresses,
       locktime,
-      minterSets[0].getThreshold()
+      threshold
     )
     // Uncomment for codecID 00 01
-    // nftMintOutput.setCodecID(codecID)
-    initialStates.addOutput(nftMintOutput, AVMConstants.NFTFXID)
-  }
+    //   secpTransferOutput.setCodecID(codecID)
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    outputs.push(transferableOutput)
 
-  const createAssetTx: CreateAssetTx = new CreateAssetTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo,
-    name,
-    symbol,
-    denomination,
-    initialStates
-  )
-  // Uncomment for codecID 00 01
-  // createAssetTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(createAssetTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO): void => {
+      const outputID: number = utxo.getOutput().getTypeID()
+      const assetID: Buffer = utxo.getAssetID()
+      if (
+        outputID === 7 &&
+        assetID.toString("hex") === avaxAssetIDBuf.toString("hex")
+      ) {
+        const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+        const amt: BN = amountOutput.getAmount().clone()
+        const txid: Buffer = utxo.getTxID()
+        const outputidx: Buffer = utxo.getOutputIdx()
+
+        const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+        // Uncomment for codecID 00 01
+        // secpTransferInput.setCodecID(codecID)
+        secpTransferInput.addSignatureIdx(0, xAddresses[0])
+
+        const input: TransferableInput = new TransferableInput(
+          txid,
+          outputidx,
+          avaxAssetIDBuf,
+          secpTransferInput
+        )
+        inputs.push(input)
+      }
+    })
+
+    const initialStates: InitialStates = new InitialStates()
+    const minterSets: MinterSet[] = [new MinterSet(threshold, xAddresses)]
+    for (let i: number = 0; i <= 5; i++) {
+      const nftMintOutput: NFTMintOutput = new NFTMintOutput(
+        groupID,
+        minterSets[0].getMinters(),
+        locktime,
+        minterSets[0].getThreshold()
+      )
+      // Uncomment for codecID 00 01
+      // nftMintOutput.setCodecID(codecID)
+      initialStates.addOutput(nftMintOutput, AVMConstants.NFTFXID)
+    }
+
+    const createAssetTx: CreateAssetTx = new CreateAssetTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo,
+      name,
+      symbol,
+      denomination,
+      initialStates
+    )
+    // Uncomment for codecID 00 01
+    // createAssetTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(createAssetTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/createKeypair.ts
+++ b/examples/avm/createKeypair.ts
@@ -9,19 +9,25 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const keychain: KeyChain = xchain.keyChain()
-  const keypair: KeyPair = keychain.makeKey()
+  try {
+    const keychain: KeyChain = xchain.keyChain()
+    const keypair: KeyPair = keychain.makeKey()
 
-  const response: {
-    address: string
-    publicKey: string
-    privateKey: string
-  } = {
-    address: keypair.getAddressString(),
-    publicKey: keypair.getPublicKeyString(),
-    privateKey: keypair.getPrivateKeyString()
+    const response: {
+      address: string
+      publicKey: string
+      privateKey: string
+    } = {
+      address: keypair.getAddressString(),
+      publicKey: keypair.getPublicKeyString(),
+      privateKey: keypair.getPrivateKeyString()
+    }
+    console.log(response)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
   }
-  console.log(response)
 }
 
 main()

--- a/examples/avm/createTXID.ts
+++ b/examples/avm/createTXID.ts
@@ -46,34 +46,40 @@ const fee: BN = xchain.getDefaultTxFee()
 const cb58: SerializedType = "cb58"
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const amount: BN = balance.sub(fee)
+  try {
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const amount: BN = balance.sub(fee)
 
-  const unsignedTx: UnsignedTx = await xchain.buildExportTx(
-    utxoSet,
-    amount,
-    pChainBlockchainID,
-    pAddressStrings,
-    xAddressStrings,
-    xAddressStrings,
-    memo,
-    asOf,
-    locktime
-  )
+    const unsignedTx: UnsignedTx = await xchain.buildExportTx(
+      utxoSet,
+      amount,
+      pChainBlockchainID,
+      pAddressStrings,
+      xAddressStrings,
+      xAddressStrings,
+      memo,
+      asOf,
+      locktime
+    )
 
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const buffer: Buffer = Buffer.from(
-    createHash("sha256").update(tx.toBuffer()).digest().buffer
-  )
-  const txid: string = serialization.bufferToType(buffer, cb58)
-  console.log(txid)
-  // APfkX9NduHkZtghRpQASNZJjLut4ZAkVhkTGeazQerLSRa36t
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const buffer: Buffer = Buffer.from(
+      createHash("sha256").update(tx.toBuffer()).digest().buffer
+    )
+    const txid: string = serialization.bufferToType(buffer, cb58)
+    console.log(txid)
+    // APfkX9NduHkZtghRpQASNZJjLut4ZAkVhkTGeazQerLSRa36t
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/exportTx-avax-cchain.ts
+++ b/examples/avm/exportTx-avax-cchain.ts
@@ -46,63 +46,69 @@ const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to C-Chain")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  exportedOuts.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
+    )
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      xAddresses,
+      locktime,
+      threshold
+    )
     // Uncomment for codecID 00 01
     // secpTransferOutput.setCodecID(codecID)
-
-    const input: TransferableInput = new TransferableInput(
-      txid,
-      outputidx,
+    const transferableOutput: TransferableOutput = new TransferableOutput(
       avaxAssetIDBuf,
-      secpTransferInput
+      secpTransferOutput
     )
-    inputs.push(input)
-  })
+    exportedOuts.push(transferableOutput)
 
-  const exportTx: ExportTx = new ExportTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo,
-    bintools.cb58Decode(cChainBlockchainID),
-    exportedOuts
-  )
-  // Uncomment for codecID 00 01
-  // exportTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO) => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amt: BN = amountOutput.getAmount().clone()
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
+
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      secpTransferInput.addSignatureIdx(0, xAddresses[0])
+      // Uncomment for codecID 00 01
+      // secpTransferOutput.setCodecID(codecID)
+
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
+    })
+
+    const exportTx: ExportTx = new ExportTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo,
+      bintools.cb58Decode(cChainBlockchainID),
+      exportedOuts
+    )
+    // Uncomment for codecID 00 01
+    // exportTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/exportTx-avax-pchain.ts
+++ b/examples/avm/exportTx-avax-pchain.ts
@@ -44,57 +44,63 @@ const locktime: BN = new BN(0)
 const memo: Buffer = Buffer.from("Manually Export AVAX from X-Chain to P-Chain")
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  exportedOuts.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO) => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amt: BN = amountOutput.getAmount().clone()
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
-
-    const input: TransferableInput = new TransferableInput(
-      txid,
-      outputidx,
-      avaxAssetIDBuf,
-      secpTransferInput
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
     )
-    inputs.push(input)
-  })
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      xAddresses,
+      locktime,
+      threshold
+    )
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    exportedOuts.push(transferableOutput)
 
-  const exportTx: ExportTx = new ExportTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo,
-    bintools.cb58Decode(pChainBlockchainID),
-    exportedOuts
-  )
-  const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO) => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amt: BN = amountOutput.getAmount().clone()
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
+
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+      secpTransferInput.addSignatureIdx(0, xAddresses[0])
+
+      const input: TransferableInput = new TransferableInput(
+        txid,
+        outputidx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
+    })
+
+    const exportTx: ExportTx = new ExportTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo,
+      bintools.cb58Decode(pChainBlockchainID),
+      exportedOuts
+    )
+    const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/exportTx-avax-to-the-pchain-and-create-a-multisig-atomic-utxo.ts
+++ b/examples/avm/exportTx-avax-to-the-pchain-and-create-a-multisig-atomic-utxo.ts
@@ -67,57 +67,63 @@ const memo: Buffer = Buffer.from(
 )
 
 const main = async (): Promise<any> => {
-  const getBalanceResponse: any = await xchain.getBalance(
-    xAddressStrings[0],
-    avaxAssetID
-  )
-  const balance: BN = new BN(getBalanceResponse.balance)
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    balance.sub(fee),
-    pAddresses,
-    locktime,
-    threshold
-  )
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  exportedOuts.push(transferableOutput)
-
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO): void => {
-    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-    const amount: BN = amountOutput.getAmount().clone()
-    const txID: Buffer = utxo.getTxID()
-    const outputIdx: Buffer = utxo.getOutputIdx()
-
-    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amount)
-    secpTransferInput.addSignatureIdx(0, xAddresses[0])
-
-    const input: TransferableInput = new TransferableInput(
-      txID,
-      outputIdx,
-      avaxAssetIDBuf,
-      secpTransferInput
+  try {
+    const getBalanceResponse: any = await xchain.getBalance(
+      xAddressStrings[0],
+      avaxAssetID
     )
-    inputs.push(input)
-  })
+    const balance: BN = new BN(getBalanceResponse.balance)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      balance.sub(fee),
+      pAddresses,
+      locktime,
+      threshold
+    )
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    exportedOuts.push(transferableOutput)
 
-  const exportTx: ExportTx = new ExportTx(
-    networkID,
-    xChainIDBuf,
-    outputs,
-    inputs,
-    memo,
-    pChainIDBuf,
-    exportedOuts
-  )
-  const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO): void => {
+      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+      const amount: BN = amountOutput.getAmount().clone()
+      const txID: Buffer = utxo.getTxID()
+      const outputIdx: Buffer = utxo.getOutputIdx()
+
+      const secpTransferInput: SECPTransferInput = new SECPTransferInput(amount)
+      secpTransferInput.addSignatureIdx(0, xAddresses[0])
+
+      const input: TransferableInput = new TransferableInput(
+        txID,
+        outputIdx,
+        avaxAssetIDBuf,
+        secpTransferInput
+      )
+      inputs.push(input)
+    })
+
+    const exportTx: ExportTx = new ExportTx(
+      networkID,
+      xChainIDBuf,
+      outputs,
+      inputs,
+      memo,
+      pChainIDBuf,
+      exportedOuts
+    )
+    const unsignedTx: UnsignedTx = new UnsignedTx(exportTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/genesisData.ts
+++ b/examples/avm/genesisData.ts
@@ -38,49 +38,55 @@ let symbol: string = "MFCA"
 let denomination: number = 1
 
 const main = async (): Promise<any> => {
-  const amount: BN = new BN(1000000000000)
-  const vcapSecpOutput = new SECPTransferOutput(
-    amount,
-    xAddresses,
-    locktime,
-    threshold
-  )
-  let initialStates: InitialStates = new InitialStates()
-  initialStates.addOutput(vcapSecpOutput)
+  try {
+    const amount: BN = new BN(1000000000000)
+    const vcapSecpOutput = new SECPTransferOutput(
+      amount,
+      xAddresses,
+      locktime,
+      threshold
+    )
+    let initialStates: InitialStates = new InitialStates()
+    initialStates.addOutput(vcapSecpOutput)
 
-  let genesisAsset: GenesisAsset = new GenesisAsset(
-    assetAlias,
-    name,
-    symbol,
-    denomination,
-    initialStates,
-    memo
-  )
-  const genesisAssets: GenesisAsset[] = [genesisAsset]
-  assetAlias = "asset2"
-  name = "asset2"
-  symbol = "MVCA"
-  denomination = 2
-  initialStates = new InitialStates()
-  const secpMintOutput: SECPMintOutput = new SECPMintOutput(
-    xAddresses,
-    locktime,
-    threshold
-  )
-  initialStates.addOutput(secpMintOutput)
-  genesisAsset = new GenesisAsset(
-    assetAlias,
-    name,
-    symbol,
-    denomination,
-    initialStates,
-    memo
-  )
-  genesisAssets.push(genesisAsset)
-  const genesisData: GenesisData = new GenesisData(genesisAssets, networkID)
-  const c: string = serialization.bufferToType(genesisData.toBuffer(), cb58)
-  console.log(c)
-  // 111113q4vh8kDKrDmvmGm1zGBKURDLcikSCbPQBjEmfnzmW5QkZpQUAXck5gt5XCgehm4HDjgj2yiTS6nekoVUgoLkQ2hQrCwc7Y7uDC99h6ThzwMz3dCLQMmfSXyuCmqwK1fw4mPnKowzxjAjchJ6w1JSxLdhTd2R9tB3qaNTPGE5BRjkZtrMyxVvWR5qxrWPhyEqy5yjxtjG2Jva2NN34tYRePo2GdKpaTwxvxguFNGTW6kUe3pu6uKVEc8Staet1xYeUa4SZnYi5Lv6xnXvc6Sj8ve1ZyRHdHkq1rCMdyKvegUXjsaT7YVYcdAG21y8sxN3FEe7eBAcLmGa8U44bN1tB8ddCWag1tusHkYjiKivWQNyMYJsavbfP5Y8gAw51YmuYy1XbiKwLJCWnj6jNG5PZE4p4anJNy3y4tj2An5ZhH
+    let genesisAsset: GenesisAsset = new GenesisAsset(
+      assetAlias,
+      name,
+      symbol,
+      denomination,
+      initialStates,
+      memo
+    )
+    const genesisAssets: GenesisAsset[] = [genesisAsset]
+    assetAlias = "asset2"
+    name = "asset2"
+    symbol = "MVCA"
+    denomination = 2
+    initialStates = new InitialStates()
+    const secpMintOutput: SECPMintOutput = new SECPMintOutput(
+      xAddresses,
+      locktime,
+      threshold
+    )
+    initialStates.addOutput(secpMintOutput)
+    genesisAsset = new GenesisAsset(
+      assetAlias,
+      name,
+      symbol,
+      denomination,
+      initialStates,
+      memo
+    )
+    genesisAssets.push(genesisAsset)
+    const genesisData: GenesisData = new GenesisData(genesisAssets, networkID)
+    const c: string = serialization.bufferToType(genesisData.toBuffer(), cb58)
+    console.log(c)
+    // 111113q4vh8kDKrDmvmGm1zGBKURDLcikSCbPQBjEmfnzmW5QkZpQUAXck5gt5XCgehm4HDjgj2yiTS6nekoVUgoLkQ2hQrCwc7Y7uDC99h6ThzwMz3dCLQMmfSXyuCmqwK1fw4mPnKowzxjAjchJ6w1JSxLdhTd2R9tB3qaNTPGE5BRjkZtrMyxVvWR5qxrWPhyEqy5yjxtjG2Jva2NN34tYRePo2GdKpaTwxvxguFNGTW6kUe3pu6uKVEc8Staet1xYeUa4SZnYi5Lv6xnXvc6Sj8ve1ZyRHdHkq1rCMdyKvegUXjsaT7YVYcdAG21y8sxN3FEe7eBAcLmGa8U44bN1tB8ddCWag1tusHkYjiKivWQNyMYJsavbfP5Y8gAw51YmuYy1XbiKwLJCWnj6jNG5PZE4p4anJNy3y4tj2An5ZhH
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getAVAXAssetID.ts
+++ b/examples/avm/getAVAXAssetID.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const assetID: Buffer = await xchain.getAVAXAssetID()
-  console.log(assetID)
+  try {
+    const assetID: Buffer = await xchain.getAVAXAssetID()
+    console.log(assetID)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getAllBalances.ts
+++ b/examples/avm/getAllBalances.ts
@@ -9,9 +9,15 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const address: string = "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p"
-  const balances: object[] = await xchain.getAllBalances(address)
-  console.log(balances)
+  try {
+    const address: string = "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p"
+    const balances: object[] = await xchain.getAllBalances(address)
+    console.log(balances)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getAssetDescription.ts
+++ b/examples/avm/getAssetDescription.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const assetDescription: any = await xchain.getAssetDescription("AVAX")
-  console.log(assetDescription)
+  try {
+    const assetDescription: any = await xchain.getAssetDescription("AVAX")
+    console.log(assetDescription)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getBalance.ts
+++ b/examples/avm/getBalance.ts
@@ -9,9 +9,15 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const address: string = "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p"
-  const balance: object = await xchain.getBalance(address, "AVAX")
-  console.log(balance)
+  try {
+    const address: string = "X-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p"
+    const balance: object = await xchain.getBalance(address, "AVAX")
+    console.log(balance)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getBlockchainAlias.ts
+++ b/examples/avm/getBlockchainAlias.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const alias: string = xchain.getBlockchainAlias()
-  console.log(alias)
+  try {
+    const alias: string = xchain.getBlockchainAlias()
+    console.log(alias)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getBlockchainID.ts
+++ b/examples/avm/getBlockchainID.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const blockchainID: string = xchain.getBlockchainID()
-  console.log(blockchainID)
+  try {
+    const blockchainID: string = xchain.getBlockchainID()
+    console.log(blockchainID)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getCreationTxFee.ts
+++ b/examples/avm/getCreationTxFee.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const txFee: BN = xchain.getCreationTxFee()
-  console.log(txFee)
+  try {
+    const txFee: BN = xchain.getCreationTxFee()
+    console.log(txFee)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getDefaultCreationTxFee.ts
+++ b/examples/avm/getDefaultCreationTxFee.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const txFee: BN = xchain.getDefaultCreationTxFee()
-  console.log(txFee)
+  try {
+    const txFee: BN = xchain.getDefaultCreationTxFee()
+    console.log(txFee)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getDefaultTxFee.ts
+++ b/examples/avm/getDefaultTxFee.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const defaultTxFee: BN = xchain.getDefaultTxFee()
-  console.log(defaultTxFee.toString())
+  try {
+    const defaultTxFee: BN = xchain.getDefaultTxFee()
+    console.log(defaultTxFee.toString())
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getInterfaces.ts
+++ b/examples/avm/getInterfaces.ts
@@ -1,11 +1,17 @@
 import { SendResponse } from "avalanche/dist/apis/avm"
 
 const main = async (): Promise<any> => {
-  const sendResponse: SendResponse = {
-    txID: "2wYzSintaK3NWk71CGBvzuieFeAzJBLYpwfypGwQMsyotcK8Zs",
-    changeAddr: "X-avax1vwf7dg22l9c0lnt92kq3urf0h9j3x6296sue77"
+  try {
+    const sendResponse: SendResponse = {
+      txID: "2wYzSintaK3NWk71CGBvzuieFeAzJBLYpwfypGwQMsyotcK8Zs",
+      changeAddr: "X-avax1vwf7dg22l9c0lnt92kq3urf0h9j3x6296sue77"
+    }
+    console.log(sendResponse)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
   }
-  console.log(sendResponse)
 }
 
 main()

--- a/examples/avm/getTx.ts
+++ b/examples/avm/getTx.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const txID: string = "Ycg5QzddNwe3ebfFXhoGUDnWgC6GE88QRakRnn9dp3nGwqCwD"
-  const encoding: string = "json"
-  const tx: string | object = await xchain.getTx(txID, encoding)
-  console.log(tx)
+  try {
+    const txID: string = "Ycg5QzddNwe3ebfFXhoGUDnWgC6GE88QRakRnn9dp3nGwqCwD"
+    const encoding: string = "json"
+    const tx: string | object = await xchain.getTx(txID, encoding)
+    console.log(tx)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getTxFee.ts
+++ b/examples/avm/getTxFee.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const txFee: BN = await xchain.getTxFee()
-  console.log(txFee)
+  try {
+    const txFee: BN = await xchain.getTxFee()
+    console.log(txFee)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/getTxStatus.ts
+++ b/examples/avm/getTxStatus.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const status: string = await xchain.getTxStatus(
-    "2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D"
-  )
-  console.log(status)
+  try {
+    const status: string = await xchain.getTxStatus(
+      "2WdpWdsqE26Qypmf66No8KeBYbNhdk3zSG7a5uNYZ3FLSvCu1D"
+    )
+    console.log(status)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/importTx-pchain.ts
+++ b/examples/avm/importTx-pchain.ts
@@ -48,60 +48,66 @@ const memo: Buffer = Buffer.from(
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: any = await xchain.getUTXOs(
-    xAddressStrings,
-    cChainBlockchainID
-  )
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxo: UTXO = utxoSet.getAllUTXOs()[0]
-  const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-  const amt: BN = amountOutput.getAmount().clone()
-  const txid: Buffer = utxo.getTxID()
-  const outputidx: Buffer = utxo.getOutputIdx()
+  try {
+    const avmUTXOResponse: any = await xchain.getUTXOs(
+      xAddressStrings,
+      cChainBlockchainID
+    )
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxo: UTXO = utxoSet.getAllUTXOs()[0]
+    const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+    const amt: BN = amountOutput.getAmount().clone()
+    const txid: Buffer = utxo.getTxID()
+    const outputidx: Buffer = utxo.getOutputIdx()
 
-  const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-  secpTransferInput.addSignatureIdx(0, xAddresses[0])
-  // Uncomment for codecID 00 01
-  // secpTransferInput.setCodecID(codecID)
+    const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
+    secpTransferInput.addSignatureIdx(0, xAddresses[0])
+    // Uncomment for codecID 00 01
+    // secpTransferInput.setCodecID(codecID)
 
-  const input: TransferableInput = new TransferableInput(
-    txid,
-    outputidx,
-    avaxAssetIDBuf,
-    secpTransferInput
-  )
-  importedInputs.push(input)
+    const input: TransferableInput = new TransferableInput(
+      txid,
+      outputidx,
+      avaxAssetIDBuf,
+      secpTransferInput
+    )
+    importedInputs.push(input)
 
-  const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-    amt.sub(fee),
-    xAddresses,
-    locktime,
-    threshold
-  )
-  // Uncomment for codecID 00 01
-  // secpTransferOutput.setCodecID(codecID)
-  const transferableOutput: TransferableOutput = new TransferableOutput(
-    avaxAssetIDBuf,
-    secpTransferOutput
-  )
-  outputs.push(transferableOutput)
+    const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+      amt.sub(fee),
+      xAddresses,
+      locktime,
+      threshold
+    )
+    // Uncomment for codecID 00 01
+    // secpTransferOutput.setCodecID(codecID)
+    const transferableOutput: TransferableOutput = new TransferableOutput(
+      avaxAssetIDBuf,
+      secpTransferOutput
+    )
+    outputs.push(transferableOutput)
 
-  const importTx: ImportTx = new ImportTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo,
-    bintools.cb58Decode(cChainBlockchainID),
-    importedInputs
-  )
-  // Uncomment for codecID 00 01
-  // importTx.setCodecID(codecID)
+    const importTx: ImportTx = new ImportTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo,
+      bintools.cb58Decode(cChainBlockchainID),
+      importedInputs
+    )
+    // Uncomment for codecID 00 01
+    // importTx.setCodecID(codecID)
 
-  const unsignedTx: UnsignedTx = new UnsignedTx(importTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const id: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${id}`)
+    const unsignedTx: UnsignedTx = new UnsignedTx(importTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const id: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${id}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/keyChain.ts
+++ b/examples/avm/keyChain.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const keyChain: KeyChain = xchain.keyChain()
-  console.log(keyChain)
+  try {
+    const keyChain: KeyChain = xchain.keyChain()
+    console.log(keyChain)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/listAddresses.ts
+++ b/examples/avm/listAddresses.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const username: string = "username"
-  const password: string = "Vz48jjHLTCcAepH95nT4B"
-  const addresses: string[] = await xchain.listAddresses(username, password)
-  console.log(addresses)
+  try {
+    const username: string = "username"
+    const password: string = "Vz48jjHLTCcAepH95nT4B"
+    const addresses: string[] = await xchain.listAddresses(username, password)
+    console.log(addresses)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/newKeyChain.ts
+++ b/examples/avm/newKeyChain.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const keyChain: KeyChain = xchain.newKeyChain()
-  console.log(keyChain)
+  try {
+    const keyChain: KeyChain = xchain.newKeyChain()
+    console.log(keyChain)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/operationTx-mint-ant.ts
+++ b/examples/avm/operationTx-mint-ant.ts
@@ -72,126 +72,132 @@ const memo: Buffer = Buffer.from("AVM manual OperationTx to mint an ANT")
 // const codecID: number = 1
 
 const main = async (): Promise<any> => {
-  const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
-  const utxoSet: UTXOSet = avmUTXOResponse.utxos
-  const utxos: UTXO[] = utxoSet.getAllUTXOs()
-  utxos.forEach((utxo: UTXO): void => {
-    const txid: Buffer = utxo.getTxID()
-    const outputidx: Buffer = utxo.getOutputIdx()
-    const assetID: Buffer = utxo.getAssetID()
-    if (utxo.getOutput().getTypeID() != 6) {
-      const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
-      const amt: BN = amountOutput.getAmount().clone()
+  try {
+    const avmUTXOResponse: any = await xchain.getUTXOs(xAddressStrings)
+    const utxoSet: UTXOSet = avmUTXOResponse.utxos
+    const utxos: UTXO[] = utxoSet.getAllUTXOs()
+    utxos.forEach((utxo: UTXO): void => {
+      const txid: Buffer = utxo.getTxID()
+      const outputidx: Buffer = utxo.getOutputIdx()
+      const assetID: Buffer = utxo.getAssetID()
+      if (utxo.getOutput().getTypeID() != 6) {
+        const amountOutput: AmountOutput = utxo.getOutput() as AmountOutput
+        const amt: BN = amountOutput.getAmount().clone()
 
-      if (assetID.toString("hex") === avaxAssetIDBuf.toString("hex")) {
-        const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-          amt.sub(fee),
-          xAddresses,
-          locktime,
-          threshold
-        )
-        // Uncomment for codecID 00 01
-        // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(
-          avaxAssetIDBuf,
-          secpTransferOutput
-        )
-        outputs.push(transferableOutput)
+        if (assetID.toString("hex") === avaxAssetIDBuf.toString("hex")) {
+          const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+            amt.sub(fee),
+            xAddresses,
+            locktime,
+            threshold
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferOutput.setCodecID(codecID)
+          const transferableOutput: TransferableOutput = new TransferableOutput(
+            avaxAssetIDBuf,
+            secpTransferOutput
+          )
+          outputs.push(transferableOutput)
 
-        const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-        // Uncomment for codecID 00 01
-        // secpTransferInput.setCodecID(codecID)
-        secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(
-          txid,
-          outputidx,
-          avaxAssetIDBuf,
-          secpTransferInput
-        )
-        inputs.push(input)
+          const secpTransferInput: SECPTransferInput = new SECPTransferInput(
+            amt
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferInput.setCodecID(codecID)
+          secpTransferInput.addSignatureIdx(0, xAddresses[0])
+          const input: TransferableInput = new TransferableInput(
+            txid,
+            outputidx,
+            avaxAssetIDBuf,
+            secpTransferInput
+          )
+          inputs.push(input)
+        } else {
+          const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
+            amt,
+            xAddresses,
+            locktime,
+            threshold
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferOutput.setCodecID(codecID)
+          const transferableOutput: TransferableOutput = new TransferableOutput(
+            assetID,
+            secpTransferOutput
+          )
+          outputs.push(transferableOutput)
+
+          const secpTransferInput: SECPTransferInput = new SECPTransferInput(
+            amt
+          )
+          // Uncomment for codecID 00 01
+          // secpTransferInput.setCodecID(codecID)
+          secpTransferInput.addSignatureIdx(0, xAddresses[0])
+          const input: TransferableInput = new TransferableInput(
+            txid,
+            outputidx,
+            assetID,
+            secpTransferInput
+          )
+          inputs.push(input)
+        }
       } else {
-        const secpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-          amt,
-          xAddresses,
-          locktime,
-          threshold
+        const vcapAmount: BN = new BN(507)
+        const vcapSecpTransferOutput: SECPTransferOutput =
+          new SECPTransferOutput(vcapAmount, xAddresses, locktime, threshold)
+        // Uncomment for codecID 00 01
+        // vcapSecpTransferOutput.setCodecID(codecID)
+        const secpMintOutputUTXOIDs: string[] = getUTXOIDs(
+          utxoSet,
+          bintools.cb58Encode(txid),
+          AVMConstants.SECPMINTOUTPUTID,
+          bintools.cb58Encode(assetID)
+        )
+        const mintOwner: SECPMintOutput = utxo.getOutput() as SECPMintOutput
+        // Uncomment for codecID 00 01
+        // mintOwner.setCodecID(codecID)
+        const secpMintOperation: SECPMintOperation = new SECPMintOperation(
+          mintOwner,
+          vcapSecpTransferOutput
         )
         // Uncomment for codecID 00 01
-        // secpTransferOutput.setCodecID(codecID)
-        const transferableOutput: TransferableOutput = new TransferableOutput(
-          assetID,
-          secpTransferOutput
-        )
-        outputs.push(transferableOutput)
+        // secpMintOperation.setCodecID(codecID)
+        const spenders: Buffer[] = mintOwner.getSpenders(xAddresses)
 
-        const secpTransferInput: SECPTransferInput = new SECPTransferInput(amt)
-        // Uncomment for codecID 00 01
-        // secpTransferInput.setCodecID(codecID)
-        secpTransferInput.addSignatureIdx(0, xAddresses[0])
-        const input: TransferableInput = new TransferableInput(
-          txid,
-          outputidx,
-          assetID,
-          secpTransferInput
-        )
-        inputs.push(input)
+        spenders.forEach((spender: Buffer) => {
+          const idx: number = mintOwner.getAddressIdx(spender)
+          secpMintOperation.addSignatureIdx(idx, spender)
+        })
+
+        const transferableOperation: TransferableOperation =
+          new TransferableOperation(
+            utxo.getAssetID(),
+            secpMintOutputUTXOIDs,
+            secpMintOperation
+          )
+        operations.push(transferableOperation)
       }
-    } else {
-      const vcapAmount: BN = new BN(507)
-      const vcapSecpTransferOutput: SECPTransferOutput = new SECPTransferOutput(
-        vcapAmount,
-        xAddresses,
-        locktime,
-        threshold
-      )
-      // Uncomment for codecID 00 01
-      // vcapSecpTransferOutput.setCodecID(codecID)
-      const secpMintOutputUTXOIDs: string[] = getUTXOIDs(
-        utxoSet,
-        bintools.cb58Encode(txid),
-        AVMConstants.SECPMINTOUTPUTID,
-        bintools.cb58Encode(assetID)
-      )
-      const mintOwner: SECPMintOutput = utxo.getOutput() as SECPMintOutput
-      // Uncomment for codecID 00 01
-      // mintOwner.setCodecID(codecID)
-      const secpMintOperation: SECPMintOperation = new SECPMintOperation(
-        mintOwner,
-        vcapSecpTransferOutput
-      )
-      // Uncomment for codecID 00 01
-      // secpMintOperation.setCodecID(codecID)
-      const spenders: Buffer[] = mintOwner.getSpenders(xAddresses)
+    })
+    const operationTx: OperationTx = new OperationTx(
+      networkID,
+      bintools.cb58Decode(blockchainID),
+      outputs,
+      inputs,
+      memo,
+      operations
+    )
 
-      spenders.forEach((spender: Buffer) => {
-        const idx: number = mintOwner.getAddressIdx(spender)
-        secpMintOperation.addSignatureIdx(idx, spender)
-      })
-
-      const transferableOperation: TransferableOperation =
-        new TransferableOperation(
-          utxo.getAssetID(),
-          secpMintOutputUTXOIDs,
-          secpMintOperation
-        )
-      operations.push(transferableOperation)
-    }
-  })
-  const operationTx: OperationTx = new OperationTx(
-    networkID,
-    bintools.cb58Decode(blockchainID),
-    outputs,
-    inputs,
-    memo,
-    operations
-  )
-
-  // Uncomment for codecID 00 01
-  // operationTx.setCodecID(codecID)
-  const unsignedTx: UnsignedTx = new UnsignedTx(operationTx)
-  const tx: Tx = unsignedTx.sign(xKeychain)
-  const txid: string = await xchain.issueTx(tx)
-  console.log(`Success! TXID: ${txid}`)
+    // Uncomment for codecID 00 01
+    // operationTx.setCodecID(codecID)
+    const unsignedTx: UnsignedTx = new UnsignedTx(operationTx)
+    const tx: Tx = unsignedTx.sign(xKeychain)
+    const txid: string = await xchain.issueTx(tx)
+    console.log(`Success! TXID: ${txid}`)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/parseAddress.ts
+++ b/examples/avm/parseAddress.ts
@@ -9,9 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const addressString: string = "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
-  const addressBuffer: Buffer = xchain.parseAddress(addressString)
-  console.log(addressBuffer)
+  try {
+    const addressString: string =
+      "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+    const addressBuffer: Buffer = xchain.parseAddress(addressString)
+    console.log(addressBuffer)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/refreshBlockchainID.ts
+++ b/examples/avm/refreshBlockchainID.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const success: boolean = xchain.refreshBlockchainID()
-  console.log(success)
+  try {
+    const success: boolean = xchain.refreshBlockchainID()
+    console.log(success)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/setAVAXAssetID.ts
+++ b/examples/avm/setAVAXAssetID.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const newAssetID: string = "11FtAxv"
-  xchain.setAVAXAssetID(newAssetID)
-  const assetID: Buffer = await xchain.getAVAXAssetID()
-  console.log(assetID)
+  try {
+    const newAssetID: string = "11FtAxv"
+    xchain.setAVAXAssetID(newAssetID)
+    const assetID: Buffer = await xchain.getAVAXAssetID()
+    console.log(assetID)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/setBlockchainAlias.ts
+++ b/examples/avm/setBlockchainAlias.ts
@@ -9,8 +9,14 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const newAlias: string = "myXChain"
-  xchain.setBlockchainAlias(newAlias)
+  try {
+    const newAlias: string = "myXChain"
+    xchain.setBlockchainAlias(newAlias)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/setCreationTxFee.ts
+++ b/examples/avm/setCreationTxFee.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const fee: BN = new BN(507)
-  xchain.setCreationTxFee(fee)
-  const txFee: BN = xchain.getCreationTxFee()
-  console.log(txFee)
+  try {
+    const fee: BN = new BN(507)
+    xchain.setCreationTxFee(fee)
+    const txFee: BN = xchain.getCreationTxFee()
+    console.log(txFee)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()

--- a/examples/avm/setTxFee.ts
+++ b/examples/avm/setTxFee.ts
@@ -9,10 +9,16 @@ const avalanche: Avalanche = new Avalanche(ip, port, protocol, networkID)
 const xchain: AVMAPI = avalanche.XChain()
 
 const main = async (): Promise<any> => {
-  const fee: BN = new BN(507)
-  xchain.setTxFee(fee)
-  const txFee: BN = xchain.getTxFee()
-  console.log(txFee)
+  try {
+    const fee: BN = new BN(507)
+    xchain.setTxFee(fee)
+    const txFee: BN = xchain.getTxFee()
+    console.log(txFee)
+  } catch (e: any) {
+    console.log(
+      "Error. Please check if all the parameters are configured correctly."
+    )
+  }
 }
 
 main()


### PR DESCRIPTION
This PR adds error handling to `admin`, `auth` and `avm` examples.

Because of no error handling, the user would get unhandled errors:
```         
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```
With the addition of error handling, the user gets a much specific error, thus knowing that the script did run, but there's a problem within the script setup:
```
Error. Please check if all the parameters are configured correctly.
```

