### PR TITLE
Update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,44 +41,140 @@ We built AvalancheJS with ease of use in mind. With this library, any Javascript
 
 AvalancheJS requires Node.js LTS version 14.16.0 or higher to compile.
 
-### Installation
+## Installation
 
-Avalanche is available for install via `yarn`:
+### Using the NPM Package
 
-`yarn add avalanche`
+Add AvalancheJS to your project via `npm` or `yarn`. 
 
-You can also pull the repo down directly and build it from scratch:
+For installing via `npm`:
+
+`npm install --save @avalabs/avalanchejs`
+
+For installing via `yarn`:
+
+`yarn add @avalabs/avalanchejs`
+
+:::caution
+
+Please note that [this](https://www.npmjs.com/package/avalanche)
+npm package is deprecated.
+Make sure to always use
+[@avalabs/avalanchejs](https://www.npmjs.com/package/@avalabs/avalanchejs)
+instead.
+
+:::
+
+### Build from Repository
+
+You can also pull the repo down directly and build it from scratch.
+
+Clone the AvalancheJS repository:
+
+`git clone https://github.com/ava-labs/avalanchejs.git`
+
+Then build it:
+
+`npm run build`
+
+or
 
 `yarn build`
 
-This will generate a pure Javascript library and place it in a folder named "web" in the project root. The "avalanche.js" file can then be dropped into any project as a pure javascript implementation of Avalanche.
+This will generate a pure JavaScript library and place it in a folder named
+"web" in the project root. The "avalanchejs" file can then be dropped into any
+project as a pure JavaScript implementation of Avalanche.
+
+![avalanchejs](/img/avalanchejs/avalanchejs-1.png)
+ 
+## Use AvalancheJS in Projects
 
 The AvalancheJS library can be imported into your existing Node.js project as follows:
 
-```js
+```ts
 const avalanche = require("avalanche")
 ```
 
 Or into your TypeScript project like this:
 
-```js
+```ts
 import { Avalanche } from "avalanche"
 ```
 
-### Importing essentials
+## Importing Essentials
 
-```js
-import { Avalanche, BinTools, BN, Buffer } from "avalanche"
+```ts
+import { Avalanche, BinTools, Buffer, BN } from "avalanche"
 
-const bintools = BinTools.getInstance()
+let bintools = BinTools.getInstance()
 ```
 
 The above lines import the libraries used in the tutorials. The libraries include:
 
-* Avalanche: Our javascript module.
-* BinTools: A singleton built into AvalancheJS that is used for dealing with binary data.
-* [BN](https://www.npmjs.com/package/bn.js): A bignumber module use by AvalancheJS.
-* [Buffer](https://www.npmjs.com/package/buffer): A Buffer library.
+- avalanche: Our JavaScript module.
+- bn.js: A big number module use by AvalancheJS.
+- buffer: A Buffer library.
+- BinTools: A singleton built into AvalancheJS that is used for dealing with binary data.
+
+## Run Scripts
+
+### TypeScript File
+
+**Via NPM**
+
+Install typescript:
+
+`npm install typescript`
+
+Run the script:
+
+`ts-node script-name.ts`
+
+**Via YARN**
+
+Install typescript:
+
+`yarn add typescript`
+
+Run the script:
+
+`ts-node script-name.ts`
+
+### JavaScript File
+
+As Node.js is already installed per [requirements](/#Requirements),
+simply run the script:
+
+`node script-name.js`
+
+### Example
+
+Let's say that the AvalancheJS repository was cloned. There are a lot of 
+useful scripts in `Examples`. Suppose the one we want to run is AVM's 
+`getTx`, which has the path `examples/avm/getTX.ts`. 
+
+To execute the script, we use: 
+
+`ts-node examples/avm/getTx.ts`
+
+It ran successfully, providing the following output:
+
+```zsh
+user@users-MacBook-Pro avalanchejs % ts-node examples/avm/getTx.ts
+{
+  unsignedTx: {
+    networkID: 1,
+    blockchainID: '11111111111111111111111111111111LpoYY',
+    outputs: [ [Object] ],
+    inputs: [ [Object] ],
+    memo: '0x',
+    destinationChain: '2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM',
+    exportedOutputs: [ [Object] ]
+  },
+  credentials: [ { signatures: [Array] } ],
+  id: 'MTyhpMPU69qLPJL59dwfYbxpWNzp8bfsHyvy9B4DkzN2kWSQ5'
+}
+```
 
 ## Example 1 &mdash; Managing X-Chain Keys
 


### PR DESCRIPTION
This PR:

- replaces all the references to the old npm package (the current one is @avalabs/avalanchejs: https://www.npmjs.com/package/@avalabs/avalanchejs)
- adds extra info for building from repo
- makes it explicit that your npm and yarn installs are made directly to a project
- adds info on how to run scripts
- adds example about how to run a script