### PR TITLE
Bech32 Encoder / Decoder

### DIFF
--- a/examples/evm/bech32AddressDecoder.ts
+++ b/examples/evm/bech32AddressDecoder.ts
@@ -1,0 +1,31 @@
+import { Buffer } from "../../src"
+import * as bech32 from "bech32"
+import { decode } from "base32-encoding"
+
+const fromDecToHex = (item: number) => {
+  let hexVal = item.toString(16)
+  let hexString = hexVal.length < 2 ? "0" + hexVal : hexVal
+  return hexString
+}
+const bech32Decoder = (item: string) => {
+  let bech32Val = item.length === 45 ? item.split("C-").join("") : item
+  //decode bech32 address into hrp and words
+  let toWords = bech32.bech32.decode(bech32Val)
+  //get buffer from words
+  const bufFromWords = Buffer.from(toWords.words)
+  //convert words array of unsigned integers from base32 (5-bit) to base256 (8-bit)
+  var base256Converted = decode(bufFromWords)
+  //get an array of unsigned integers from the buffer obtained
+  let arrBase256Converted = [...base256Converted]
+  //convert each integer to its hex value
+  let hexValue = arrBase256Converted.map((item) => fromDecToHex(item))
+  return "0x" + hexValue.toString().split(",").join("")
+}
+
+const main = async (): Promise<any> => {
+  const txID: string = "C-avax1hwgqh0s6yrdy636xv6me5haxecfx99enh5278a"
+  const bech32DecodedAddress = bech32Decoder(txID)
+  console.log("Decoded address (0x format): " + bech32DecodedAddress)
+}
+
+main()

--- a/examples/evm/bech32AddressDecoder.ts
+++ b/examples/evm/bech32AddressDecoder.ts
@@ -23,6 +23,7 @@ const bech32Decoder = (item: string) => {
 }
 
 const main = async (): Promise<any> => {
+  //can be used for P and X addresses too
   const txID: string = "C-avax1hwgqh0s6yrdy636xv6me5haxecfx99enh5278a"
   const bech32DecodedAddress = bech32Decoder(txID)
   console.log("Decoded address (0x format): " + bech32DecodedAddress)

--- a/examples/evm/bech32AddressEncoder.ts
+++ b/examples/evm/bech32AddressEncoder.ts
@@ -12,6 +12,7 @@ const bech32Encoder = (item: string) => {
   let arrBuf = [...bufFromHex]
   let bech32Address = bech32.bech32.encode(hrp, bech32.bech32.toWords(arrBuf))
   return "C-" + bech32Address
+  //to get P and X chains format, just change the C- prefix to P- or X-
 }
 
 const main = async (): Promise<any> => {

--- a/examples/evm/bech32AddressEncoder.ts
+++ b/examples/evm/bech32AddressEncoder.ts
@@ -1,0 +1,23 @@
+import { Buffer } from "../../src"
+import * as bech32 from "bech32"
+
+const fromDecToHex = (item: number) => {
+  let hexVal = item.toString(16)
+  let hexString = hexVal.length < 2 ? "0" + hexVal : hexVal
+  return hexString
+}
+const bech32Encoder = (item: string) => {
+  let hrp = "avax"
+  const bufFromHex = Buffer.from(item.slice(2), "hex")
+  let arrBuf = [...bufFromHex]
+  let bech32Address = bech32.bech32.encode(hrp, bech32.bech32.toWords(arrBuf))
+  return "C-" + bech32Address
+}
+
+const main = async (): Promise<any> => {
+  const txID: string = "0xBB900BbE1A20dA4d474666B79a5fa6CE12629733"
+  const encodedAddress = bech32Encoder(txID)
+  console.log("Bech32 encoded address: " + encodedAddress)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "dependencies": {
     "assert": "2.0.0",
     "axios": "0.27.2",
+    "base32-encoding": "^1.0.0",
     "bech32": "2.0.0",
     "bip39": "3.1.0",
     "bn.js": "5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,6 +2018,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base32-encoding@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base32-encoding/-/base32-encoding-1.0.0.tgz#3f46a6adb4d6b7e5cf0f294392c1f9ec600da27b"
+  integrity sha512-k1gA7f00ODLY7YtuEQFz0Kn3huTCmL/JW+oQtw51ID+zxs5chj/YQ1bXN+Q0JsqiKB2Yn0oA0AA8uipFYgpagQ==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"


### PR DESCRIPTION
Many users want to convert 0x addresses to bech32, and vice-versa. Added two scripts which achieve that. They target C-Chain addresses, but can be used for any chain, just change the prefix.

### Bech32 encoder output
Encoding 0xBB900BbE1A20dA4d474666B79a5fa6CE12629733
```
laviniatalpas@Lavinias-MacBook-Pro avalanchejs % ts-node examples/evm/bech32AddressEncoder            
Bech32 encoded address: C-avax1hwgqh0s6yrdy636xv6me5haxecfx99enh5278a
```

### Bech32 decoder output
Decoding C-avax1hwgqh0s6yrdy636xv6me5haxecfx99enh5278a:
```
laviniatalpas@Lavinias-MacBook-Pro avalanchejs % ts-node examples/evm/bech32AddressDecoder            
Decoded address (0x format): 0xbb900bbe1a20da4d474666b79a5fa6ce12629733
```
