### PR TITLE
fix: reference ES module on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@avalabs/avalanchejs",
   "version": "4.0.3",
   "description": "Avalanche Platform JS Library",
-  "main": "dist/index.js",
+  "main": "dist/es/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "type": "module",


### PR DESCRIPTION
Since package type is "module", main should reference the built ES module file.

This will fix run times that still use `main` as the entry point.