### PR TITLE
chore: build cjs files for resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "@avalabs/avalanchejs",
   "version": "4.0.4",
   "description": "Avalanche Platform JS Library",
-  "main": "dist/es/index.js",
+  "main": "dist/es/index.cjs",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "type": "module",
   "exports": {
     "import": "./dist/es/index.js",
-    "require": "./dist/index.js"
+    "require": "./dist/index.cjs",
+    "default": "./dist/es/index.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@avalabs/avalanchejs",
   "version": "4.0.4",
   "description": "Avalanche Platform JS Library",
-  "main": "dist/es/index.cjs",
+  "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "type": "module",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -13,7 +13,7 @@ export default {
   ], // we don't want these dependencies bundled in the dist folder
   output: [
     {
-      file: 'dist/index.js',
+      file: 'dist/index.cjs',
       format: 'cjs',
       plugins: [terser()],
       sourcemap: process.env.BUILD === 'production' ? false : true,


### PR DESCRIPTION
Addresses issues like:
```
 Error: require() of ES Module /[redacted]/node_modules/@avalabs/avalanchejs/dist/index.js from /[redacted]/node_modules/@avalabs/utils-sdk/dist/index.js not supported.
@core/shared:test: /[redacted]/node_modules/@avalabs/avalanchejs/dist/index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
```