### PR TITLE
Add nodePOP in info.getNodeID

### DIFF
--- a/src/info/model.ts
+++ b/src/info/model.ts
@@ -46,8 +46,14 @@ export type UptimeResponse = {
   weightedAveragePercentage: string;
 };
 
+export type NodePOP = {
+  publicKey: string;
+  proofOfPossession: string;
+};
+
 export type GetNodeIdResponse = {
   nodeID: string;
+  nodePOP: NodePOP;
 };
 
 export type GetNodeIpResponse = {


### PR DESCRIPTION
Let's include `nodePOP` in the response so that we can pass it to `newAddPermissionlessValidatorTx` to stake in the primary network.