### PR TITLE
networkID from /ext/info is a string

### DIFF
--- a/src/info/model.ts
+++ b/src/info/model.ts
@@ -55,7 +55,7 @@ export type GetNodeIpResponse = {
 };
 
 export type GetNetworkIdResponse = {
-  networkID: number;
+  networkID: string;
 };
 
 export type GetNetworkNameResponse = {

--- a/src/vms/context/context.ts
+++ b/src/vms/context/context.ts
@@ -31,6 +31,7 @@ export const getContextFromURI = async (
   const { blockchainID: cBlockchainID } = await info.getBlockchainId('C');
 
   const { networkID } = await info.getNetworkId();
+  const networkIDNum = Number.parseInt(networkID);
 
   return Object.freeze({
     xBlockchainID,
@@ -46,7 +47,7 @@ export const getContextFromURI = async (
     addPrimaryNetworkDelegatorFee,
     addSubnetValidatorFee,
     addSubnetDelegatorFee,
-    networkID,
-    hrp: getHRP(networkID),
+    networkID: networkIDNum,
+    hrp: getHRP(networkIDNum),
   });
 };


### PR DESCRIPTION
On AvalancheGo side, the method `info.getNetworkID` returns the `networkID` field as a string as it's marshaled from `json.Uint32` (defined [here](https://github.com/ava-labs/avalanchego/blob/52dd10f64f760ada007ba5eb9e2788f70c239ad4/api/info/service.go#L142)).  In the client side, however, we receive it as a `number`.  With this miscast, the client accidentally considers the returned network ID as a hex string, and thus a submitted tx is always rejected due to network id mismatch.  For example, when the client sends a tx to Local Network (id=1337), it sets networkID to 0x1337.

The proposed fix is to change the type of `networkID` from number to string to match AvalancheGo implementation.