### PR TITLE
correct NetworkID

### DIFF
--- a/src/vms/context/context.ts
+++ b/src/vms/context/context.ts
@@ -46,7 +46,7 @@ export const getContextFromURI = async (
     addPrimaryNetworkDelegatorFee,
     addSubnetValidatorFee,
     addSubnetDelegatorFee,
-    networkID,
+    networkID: Number(networkID),
     hrp: getHRP(networkID),
   });
 };


### PR DESCRIPTION
when running `yarn run example` I get the following error: 

`error: couldn't issue tx: failed to verify transfer: invalid signature`

typecasting the context fixes this issue. 