### PR TITLE
fix: package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avalabs/avalanchejs",
-  "version": "4.0.5",
+  "version": "4.1.1",
   "description": "Avalanche Platform JS Library",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
CI on master is failing: https://github.com/ava-labs/avalanchejs/actions/runs/11075195268/job/30775612234
Because of this tag: https://github.com/ava-labs/avalanchejs/releases/tag/v4.1.0-alpha.1

Will bumping the version in package.json fix this?