### PR TITLE
feat: add nodePOP to GetNodeIdResponse"

### DIFF
--- a/src/info/model.ts
+++ b/src/info/model.ts
@@ -46,8 +46,14 @@ export type UptimeResponse = {
   weightedAveragePercentage: string;
 };
 
+export type NodePOP = {
+  publicKey: string;
+  proofOfPossession: string;
+};
+
 export type GetNodeIdResponse = {
   nodeID: string;
+  nodePOP: NodePOP;
 };
 
 export type GetNodeIpResponse = {

--- a/src/vms/pvm/etna-builder/builder.ts
+++ b/src/vms/pvm/etna-builder/builder.ts
@@ -1350,7 +1350,7 @@ export type NewConvertSubnetTxProps = TxProps<{
    */
   subnetId: string;
   /**
-   * Specifies the address of the manager
+   * Specifies the address of the validator manager
    */
   address: Uint8Array;
   /**
@@ -1564,6 +1564,8 @@ export const newRegisterSubnetValidatorTx: TxBuilderFn<
 export type SetSubnetValidatorWeightTxProps = TxProps<{
   /**
    * Warp message bytes.
+   *
+   * A ValidatorWeight message payload.
    */
   message: Uint8Array;
 }>;


### PR DESCRIPTION
- **fix: add nodePOP to getNodeId response**
- **docs: add more specifics to etna tx props**

---
```
curl --location 'https://etna.avax-dev.network/ext/info' --header 'Content-Type: application/json' --data '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"info.getNodeID"
}' | jq
```