### PR TITLE
feat: add necessary APIs to facilitate DisableL1ValidatorTx signing

### DIFF
--- a/src/serializable/pvm/disableL1ValidatorTx.ts
+++ b/src/serializable/pvm/disableL1ValidatorTx.ts
@@ -42,4 +42,13 @@ export class DisableL1ValidatorTx extends PVMTx {
   getDisableAuth() {
     return this.disableAuth as Input;
   }
+
+  getSigIndices(): number[][] {
+    return [
+      ...this.getInputs().map((input) => {
+        return input.sigIndicies();
+      }),
+      this.getDisableAuth().values(),
+    ].filter((indicies): indicies is number[] => indicies !== undefined);
+  }
 }

--- a/src/vms/pvm/api.ts
+++ b/src/vms/pvm/api.ts
@@ -292,6 +292,9 @@ export class PVMApi extends AvaxApi {
       weight: BigInt(resp.weight),
       deactivationOwner,
       remainingBalanceOwner,
+      startTime: BigInt(resp.startTime),
+      height: BigInt(resp.height),
+      minNonce: BigInt(resp.minNonce),
     };
   }
 }

--- a/src/vms/pvm/models.ts
+++ b/src/vms/pvm/models.ts
@@ -1,3 +1,4 @@
+import type { PChainOwner } from '../../serializable';
 import type { TransferableOutput } from '../../serializable/avax';
 import type { Utxo } from '../../serializable/avax/utxo';
 import type { Dimensions } from '../common/fees/dimensions';
@@ -304,4 +305,35 @@ export interface FeeState {
   price: bigint;
   /** ISO8601 DateTime */
   timestamp: string;
+}
+
+export interface GetL1ValidatorResponse {
+  subnetID: string;
+  nodeID: string;
+  publicKey: string;
+  remainingBalanceOwner: {
+    addresses: string[];
+    locktime: string;
+    threshold: string;
+  };
+  deactivationOwner: {
+    addresses: string[];
+    locktime: string;
+    threshold: string;
+  };
+  startTime: string;
+  weight: string;
+  minNonce: string;
+  balance: string;
+  height: string;
+}
+
+export interface L1ValidatorDetails {
+  subnetID: string;
+  nodeID: string;
+  publicKey: string;
+  remainingBalanceOwner: PChainOwner;
+  deactivationOwner: PChainOwner;
+  weight: bigint;
+  balance: bigint;
 }

--- a/src/vms/pvm/models.ts
+++ b/src/vms/pvm/models.ts
@@ -336,4 +336,7 @@ export interface L1ValidatorDetails {
   deactivationOwner: PChainOwner;
   weight: bigint;
   balance: bigint;
+  startTime: bigint;
+  minNonce: bigint;
+  height: bigint;
 }


### PR DESCRIPTION
* `.getL1Validator()` api call is needed so we know the addresses required to sign `disableAuth`
* similar for `.getSigIndices()`