### PR TITLE
fix: sort addresses

### DIFF
--- a/src/utils/addressMap.test.ts
+++ b/src/utils/addressMap.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { address } from '../fixtures/common';
 import { Address } from '../serializable/fxs/common';
 import { AddressMap, AddressMaps, matchOwners } from './addressMap';
@@ -245,67 +245,65 @@ describe('AddressMaps', () => {
 });
 
 describe('matchOwners', () => {
-  it('matches owners', () => {
-    const owner1 = address();
-    const owner2 = Address.fromHex('7db97c7cece249c2b98bdc0226cc4c2a57bf52fc');
-    const ownerAddresses: Uint8Array[] = [owner1.toBytes(), owner2.toBytes()];
-    const goodOwner = OutputOwners.fromNative(ownerAddresses, 0n, 1);
-    const threasholdTooHigh = OutputOwners.fromNative(ownerAddresses, 0n, 5);
-    const wrongOwner = OutputOwners.fromNative(
-      [hexToBuffer('0x12345123451234512345')],
-      0n,
-      5,
-    );
-    const locked = OutputOwners.fromNative(
-      ownerAddresses,
-      9999999999999999999999999999999999n,
-      5,
-    );
+  const owner1 = address();
+  const owner2 = Address.fromHex('7db97c7cece249c2b98bdc0226cc4c2a57bf52fc');
+  const ownerAddresses: Uint8Array[] = [owner1.toBytes(), owner2.toBytes()];
+  const goodOwner = OutputOwners.fromNative(ownerAddresses, 0n, 1);
+  const threasholdTooHigh = OutputOwners.fromNative(ownerAddresses, 0n, 5);
+  const wrongOwner = OutputOwners.fromNative(
+    [hexToBuffer('0x12345123451234512345')],
+    0n,
+    5,
+  );
+  const locked = OutputOwners.fromNative(
+    ownerAddresses,
+    9999999999999999999999999999999999n,
+    5,
+  );
 
-    const specs = [
-      {
-        testCase: goodOwner,
-        expectedSigIndices: [0],
-        expectedAddressMap: new AddressMap([[owner1, 0]]),
-      },
-      {
-        testCase: threasholdTooHigh,
-        expectedSigIndices: undefined,
-        expectedAddressMap: undefined,
-      },
-      {
-        testCase: locked,
-        expectedSigIndices: undefined,
-        expectedAddressMap: undefined,
-      },
-      {
-        testCase: wrongOwner,
-        expectedSigIndices: undefined,
-        expectedAddressMap: undefined,
-      },
-      {
-        testCase: goodOwner,
-        sigindices: [1],
-        expectedSigIndices: [1],
-        expectedAddressMap: new AddressMap([[owner2, 1]]),
-      },
-      {
-        testCase: goodOwner,
-        sigindices: [2],
-        expectedSigIndices: undefined,
-        expectedAddressMap: undefined,
-      },
-    ];
+  const specs = [
+    {
+      testCase: goodOwner,
+      expectedSigIndices: [0],
+      expectedAddressMap: new AddressMap([[owner2, 0]]),
+    },
+    {
+      testCase: threasholdTooHigh,
+      expectedSigIndices: undefined,
+      expectedAddressMap: undefined,
+    },
+    {
+      testCase: locked,
+      expectedSigIndices: undefined,
+      expectedAddressMap: undefined,
+    },
+    {
+      testCase: wrongOwner,
+      expectedSigIndices: undefined,
+      expectedAddressMap: undefined,
+    },
+    {
+      testCase: goodOwner,
+      sigindices: [1],
+      expectedSigIndices: [1],
+      expectedAddressMap: new AddressMap([[owner1, 1]]),
+    },
+    {
+      testCase: goodOwner,
+      sigindices: [2],
+      expectedSigIndices: undefined,
+      expectedAddressMap: undefined,
+    },
+  ];
 
-    specs.forEach((spec) => {
-      const result = matchOwners(
-        spec.testCase,
-        addressesFromBytes(ownerAddresses),
-        50n,
-        spec.sigindices,
-      );
-      expect(result?.sigIndicies).toEqual(spec.expectedSigIndices);
-      expect(result?.addressMap).toEqual(spec.expectedAddressMap);
-    });
+  test.each(specs)('matchOwners($testCase, $sigIndices)', (spec) => {
+    const result = matchOwners(
+      spec.testCase,
+      addressesFromBytes(ownerAddresses),
+      50n,
+      spec.sigindices,
+    );
+    expect(result?.sigIndicies).toEqual(spec.expectedSigIndices);
+    expect(result?.addressMap).toEqual(spec.expectedAddressMap);
   });
 });

--- a/src/utils/addressMap.test.ts
+++ b/src/utils/addressMap.test.ts
@@ -248,7 +248,9 @@ describe('matchOwners', () => {
   const owner1 = address();
   const owner2 = Address.fromHex('7db97c7cece249c2b98bdc0226cc4c2a57bf52fc');
   const ownerAddresses: Uint8Array[] = [owner1.toBytes(), owner2.toBytes()];
+  // NOTE: the ownerAddresses will be sorted in the OutputOwners -- owner2 is at index 0.
   const goodOwner = OutputOwners.fromNative(ownerAddresses, 0n, 1);
+  const goodOwnerMultisig = OutputOwners.fromNative(ownerAddresses, 0n, 2);
   const threasholdTooHigh = OutputOwners.fromNative(ownerAddresses, 0n, 5);
   const wrongOwner = OutputOwners.fromNative(
     [hexToBuffer('0x12345123451234512345')],
@@ -287,6 +289,15 @@ describe('matchOwners', () => {
       sigindices: [1],
       expectedSigIndices: [1],
       expectedAddressMap: new AddressMap([[owner1, 1]]),
+    },
+    {
+      testCase: goodOwnerMultisig,
+      sigindices: [0, 1],
+      expectedSigIndices: [0, 1],
+      expectedAddressMap: new AddressMap([
+        [owner2, 0],
+        [owner1, 1],
+      ]),
     },
     {
       testCase: goodOwner,

--- a/src/utils/addressesFromBytes.ts
+++ b/src/utils/addressesFromBytes.ts
@@ -1,5 +1,7 @@
 import { Address } from '../serializable/fxs/common';
+import { bytesCompare } from './bytesCompare';
 
 export function addressesFromBytes(bytes: readonly Uint8Array[]): Address[] {
-  return bytes.map((b) => new Address(b));
+  const sortedBytes = bytes.toSorted(bytesCompare);
+  return sortedBytes.map((b) => new Address(b));
 }


### PR DESCRIPTION
Preventing errors such as:
```
Details: couldn't issue tx: failed verification: failed execution: standard tx 5BFNdkBJWZhqx3NkrnHMEhetJ4YtZC5QxLdNREGJGF9XznGvf failed execution: output failed verification: addresses not sorted and unique
```

reproduction steps (on `master`):
in `examples/p-chain/base.ts`, testing against fuji:
add the following lines options:
```typescript
  const P_CHAIN_ADDRESS_2 = 'P-fuji14n4duc4qkmh4q5vvgyh03yrcf4yxtk2ap8mj8q';
  const changeAddresses = [
    bech32ToBytes(P_CHAIN_ADDRESS_2),
    bech32ToBytes(P_CHAIN_ADDRESS),
  ];
  changeAddresses.sort(bytesCompare);
  changeAddresses.reverse(); // NOTE: this will cause the error
  const tx = newBaseTx(context, [bech32ToBytes(P_CHAIN_ADDRESS)], utxos, [
    TransferableOutput.fromNative(context.avaxAssetID, BigInt(0.01 * 1e9), [
      bech32ToBytes(P_CHAIN_ADDRESS)
    ]),
  ], 
  {
    changeAddresses
  }
```
this should throw the error on master, but not on this branch.



after applying this fix, even this is fine:
```typescript
  const { utxos } = await pvmapi.getUTXOs({ addresses: [P_CHAIN_ADDRESS, P_CHAIN_ADDRESS_2] });
  // NOTE: backwards sorted fromAddressBytes
  const tx = newBaseTx(context, [bech32ToBytes(P_CHAIN_ADDRESS_2), bech32ToBytes(P_CHAIN_ADDRESS)], utxos, [
    TransferableOutput.fromNative(context.avaxAssetID, BigInt(0.01 * 1e9), [
      bech32ToBytes(P_CHAIN_ADDRESS)
    ]),
  ], 
  {
    changeAddresses
  }
```

https://subnets-test.avax.network/p-chain/tx/Jjw7T3exyvJeBkEZqQhK87SBTrTu4Wj5DUrhj8Dc2RjdwAPra