### PR TITLE
chore: add extra entropy to secp256k1 sig

### DIFF
--- a/src/crypto/secp256k1.test.ts
+++ b/src/crypto/secp256k1.test.ts
@@ -54,12 +54,16 @@ describe('secp256k1', function () {
     for (const test of tests) {
       const hash = sha256(test.msg);
 
-      await expect(secp256k1.sign(test.msg, privKey)).resolves.toEqual(
-        test.sig,
-      );
-      await expect(secp256k1.signHash(hash, privKey)).resolves.toEqual(
-        test.sig,
-      );
+      await expect(
+        secp256k1.sign(test.msg, privKey, { extraEntropy: false }),
+      ).resolves.toEqual(test.sig);
+      await expect(
+        secp256k1.signHash(hash, privKey, { extraEntropy: false }),
+      ).resolves.toEqual(test.sig);
+      const defaultSig = await secp256k1.sign(test.msg, privKey);
+      expect(defaultSig).not.toEqual(test.sig); // Entropy is added
+      expect(secp256k1.recoverPublicKey(hash, defaultSig)).toEqual(pubKey);
+      expect(secp256k1.verify(defaultSig, hash, pubKey)).toEqual(true);
       expect(secp256k1.recoverPublicKey(hash, test.sig)).toEqual(pubKey);
       expect(secp256k1.verify(test.sig, hash, pubKey)).toEqual(true);
     }

--- a/src/crypto/secp256k1.ts
+++ b/src/crypto/secp256k1.ts
@@ -11,12 +11,25 @@ export function randomPrivateKey() {
   return secp.utils.randomPrivateKey();
 }
 
-export function sign(msg: Uint8Array | string, privKey: Uint8Array) {
-  return signHash(sha256(msg), privKey);
+export type SignOptions = Parameters<typeof secp.signAsync>[2];
+
+export function sign(
+  msg: Uint8Array | string,
+  privKey: Uint8Array,
+  options: SignOptions = {},
+) {
+  return signHash(sha256(msg), privKey, options);
 }
 
-export async function signHash(hash: Uint8Array, privKey: Uint8Array) {
-  const sig = await secp.signAsync(hash, privKey);
+export async function signHash(
+  hash: Uint8Array,
+  privKey: Uint8Array,
+  options: SignOptions = {},
+) {
+  const sig = await secp.signAsync(hash, privKey, {
+    extraEntropy: true,
+    ...options,
+  });
 
   if (sig.recovery !== undefined) {
     return concatBytes(sig.toCompactRawBytes(), new Uint8Array([sig.recovery]));

--- a/src/signer/addTxSignatures.test.ts
+++ b/src/signer/addTxSignatures.test.ts
@@ -74,16 +74,6 @@ describe('addTxSignatures', () => {
     expect(hasPubkeySpy).toHaveBeenNthCalledWith(3, unknownPublicKey);
 
     expect(addSignatureSpy).toHaveBeenCalledTimes(2);
-    expect(addSignatureSpy).toHaveBeenCalledWith(
-      hexToBuffer(
-        '0x7b3da43d8e4103d1078061872075cbcbb5de0108f3d897752c894757cf0e9c4113949ca2a5568483763e1fa0e74b4f4dd9b2a6e40909d0729f87c7dddfc1e70601',
-      ),
-    );
-    expect(addSignatureSpy).toHaveBeenCalledWith(
-      hexToBuffer(
-        '0x04e2072e34fd5d7cc729afb8bfe7c5865754c3c448b9b3247b16cabbf06378393edf405274048bef74c02862ae032c0b86dda7c28bebf63f4d1de4f517bd710500',
-      ),
-    );
 
     expect(unsignedTx.hasAllSignatures()).toBe(true);
   });


### PR DESCRIPTION
Seems like adding extra entropy when available would be a strict security improvement