### PR TITLE
feat: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avalabs/avalanchejs",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Avalanche Platform JS Library",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE:
The old PVM transaction builder has been removed. The new Etna builder is now the default builder in order to support dynamic fees. Static fees on P-chain are not longer applicable. Likewise, API's referring to retrieving static fees have been removed where no longer applicable, and new X-Chain specific API's have been added to cover retrieving static tx fees specific to X-Chain transactions. The `e` alias on `pvm` (ie `pvm.e.{builderMethod}`) has been marked deprecated since the builder methods are now directly available on the `pvm` export.