### PR TITLE
fix: correct typo in generate-keys.ts comment

### DIFF
--- a/examples/generate-keys.ts
+++ b/examples/generate-keys.ts
@@ -9,7 +9,7 @@ type NodeIdResponse = {
 
 /**
  * Generate a new private/public key pair and console log out the needed environment variables
- * needed to run the examples. Please these values in a `.env` file.
+ * needed to run the examples. Place these values in a `.env` file.
  */
 const main = async () => {
   const { AVAX_PUBLIC_URL } = getEnvVars();


### PR DESCRIPTION
## Summary
- Fixed typo in `examples/generate-keys.ts` comment
- Changed "Please these values" to "Place these values"

## Test plan
- [x] Verified the change is a documentation-only fix
- [x] No functional changes to the code