### PR TITLE
fix: correct typo in UnsignedTx type name

### DIFF
--- a/src/vms/common/unsignedTx.ts
+++ b/src/vms/common/unsignedTx.ts
@@ -12,7 +12,7 @@ import { AddressMaps } from '../../utils/addressMap';
 import { getManagerForVM, packTx } from '../../utils/packTx';
 import type { Transaction } from './transaction';
 
-type UnsingedTxSerialize = {
+type UnsignedTxSerialize = {
   txBytes: string;
   utxos: string[];
   addressMaps: [string, number][][];
@@ -51,7 +51,7 @@ export class UnsignedTx {
   }
 
   static fromJSON(jsonString: string) {
-    const res = JSON.parse(jsonString) as UnsingedTxSerialize;
+    const res = JSON.parse(jsonString) as UnsignedTxSerialize;
 
     const fields = [
       'txBytes',


### PR DESCRIPTION
## Summary
- Fixed typo in internal type name in `src/vms/common/unsignedTx.ts`
- Renamed `UnsingedTxSerialize` to `UnsignedTxSerialize`

## Test plan
- [x] This is a type name only change with no runtime impact
- [x] The type is internal and not exported, so no breaking changes