### PR TITLE
fix: correct typo in addressMap.ts comment

### DIFF
--- a/src/utils/addressMap.ts
+++ b/src/utils/addressMap.ts
@@ -133,7 +133,7 @@ export class AddressMaps {
   }
 
   // this is a stopgap to quickly fix AddressMap not deriving the order post sorting TransferableInputs. Can probably
-  // be simplified a lot by just deriving the sigIndicies right before returning the unsingedTx
+  // be simplified a lot by just deriving the sigIndicies right before returning the unsignedTx
   static fromTransferableInputs(
     inputs: readonly TransferableInput[],
     inputUtxos: readonly Utxo[],


### PR DESCRIPTION
## Summary
- Fixed typo in comment in `src/utils/addressMap.ts`
- Changed "unsingedTx" to "unsignedTx"

## Test plan
- [x] Verified the change is a comment-only fix
- [x] No functional changes to the code