### PR TITLE
fix: correct typo in spend.ts JSDoc comment

### DIFF
--- a/src/vms/pvm/etna-builder/spend.ts
+++ b/src/vms/pvm/etna-builder/spend.ts
@@ -75,7 +75,7 @@ export type SpendProps = Readonly<{
    */
   toBurn?: Map<string, bigint>;
   /**
-   * Maps `assetID` to the amount of the asset to spend and place info
+   * Maps `assetID` to the amount of the asset to spend and place into
    * the staked outputs. First locked UTXOs are attempted to be used for
    * these funds, and then unlocked UTXOs will be attempted to be used.
    * There is no preferential ordering on the unlock times.


### PR DESCRIPTION
## Summary
- Fixed typo in JSDoc comment in `src/vms/pvm/etna-builder/spend.ts`
- Changed "place info" to "place into" in the `toStake` property documentation

## Test plan
- [x] Verified the change is a documentation-only fix
- [x] No functional changes to the code