### PR TITLE
ci: use latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
           package-manager-cache: false # never use caching in release builds
       - run: yarn install --frozen-lockfile
       - run: yarn build:prod
-      - run: npm publish # Or: npm stage publish
+      - run: npm publish --tag=latest # Or: npm stage publish


### PR DESCRIPTION
Needed because someone published a `99.99.99` version at some point in the history of this package.