### PR TITLE
ci: use either alpha or latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,10 @@ jobs:
           package-manager-cache: false # never use caching in release builds
       - run: yarn install --frozen-lockfile
       - run: yarn build:prod
-      - run: npm publish --tag=latest # Or: npm stage publish
+      - name: Publish to npm
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == *alpha* ]]; then
+            npm publish --tag=alpha
+          else
+            npm publish --tag=latest
+          fi


### PR DESCRIPTION
don't always use "latest" tag. Make sure that any "alpha" builds get an "alpha" tag for now.