### PR TITLE
fix: align acp-236 transactions encoding

### DIFF
--- a/src/fixtures/pvm.ts
+++ b/src/fixtures/pvm.ts
@@ -401,7 +401,6 @@ export const addAutoRenewedValidatorTx = () =>
     outputOwner(),
     outputOwner(),
     int(),
-    bigIntPr(),
     int(),
     bigIntPr(),
   );
@@ -409,6 +408,7 @@ export const addAutoRenewedValidatorTx = () =>
 export const addAutoRenewedValidatorTxBytes = () =>
   concatBytes(
     baseTxbytes(),
+    bytesForInt(nodeIdBytes().length),
     nodeIdBytes(),
     bytesForInt(28),
     signerBytes(),
@@ -420,7 +420,6 @@ export const addAutoRenewedValidatorTxBytes = () =>
     bytesForInt(11),
     outputOwnerBytes(),
     intBytes(),
-    bigIntPrBytes(),
     intBytes(),
     bigIntPrBytes(),
   );

--- a/src/serializable/pvm/addAutoRenewedValidatorTx.ts
+++ b/src/serializable/pvm/addAutoRenewedValidatorTx.ts
@@ -6,7 +6,7 @@ import { serializable } from '../common/types';
 import { Codec } from '../codec';
 import { concatBytes } from '../../utils/buffer';
 import { pack, unpack } from '../../utils/struct';
-import { BigIntPr, Int } from '../primitives';
+import { BigIntPr, Bytes, Int } from '../primitives';
 import { packList, toListStruct } from '../../utils/serializeList';
 import { Signer } from './signer';
 import type { OutputOwners } from '../fxs/secp256k1';
@@ -24,9 +24,8 @@ export class AddAutoRenewedValidatorTx extends PVMTx {
     public readonly stake: readonly TransferableOutput[],
     public readonly validatorRewardsOwner: Serializable,
     public readonly delegatorRewardsOwner: Serializable,
-    public readonly owner: Serializable,
-    public readonly shares: Int,
-    public readonly weight: BigIntPr,
+    public readonly validatorAuthority: Serializable,
+    public readonly delegationShares: Int,
     public readonly autoCompoundRewardShares: Int,
     public readonly period: BigIntPr,
   ) {
@@ -41,8 +40,8 @@ export class AddAutoRenewedValidatorTx extends PVMTx {
     return this.delegatorRewardsOwner as OutputOwners;
   }
 
-  getOwner() {
-    return this.owner as OutputOwners;
+  getValidatorAuthority() {
+    return this.validatorAuthority as OutputOwners;
   }
 
   static fromBytes(
@@ -51,14 +50,13 @@ export class AddAutoRenewedValidatorTx extends PVMTx {
   ): [AddAutoRenewedValidatorTx, Uint8Array] {
     const [
       baseTx,
-      nodeId,
+      nodeIdBytes,
       signer,
       stakeOuts,
       validatorRewardsOwner,
       delegatorRewardsOwner,
-      owner,
+      validatorAuthority,
       delegationShares,
-      weight,
       autoCompoundRewardShares,
       period,
       rest,
@@ -66,14 +64,13 @@ export class AddAutoRenewedValidatorTx extends PVMTx {
       bytes,
       [
         BaseTx,
-        NodeId,
+        Bytes,
         Codec,
         toListStruct(TransferableOutput),
         Codec,
         Codec,
         Codec,
         Int,
-        BigIntPr,
         Int,
         BigIntPr,
       ],
@@ -89,14 +86,13 @@ export class AddAutoRenewedValidatorTx extends PVMTx {
     return [
       new AddAutoRenewedValidatorTx(
         baseTx,
-        nodeId,
+        new NodeId(nodeIdBytes.bytes),
         signer,
         stakeOuts,
         validatorRewardsOwner,
         delegatorRewardsOwner,
-        owner,
+        validatorAuthority,
         delegationShares,
-        weight,
         autoCompoundRewardShares,
         period,
       ),
@@ -106,14 +102,14 @@ export class AddAutoRenewedValidatorTx extends PVMTx {
 
   toBytes(codec: Codec): Uint8Array {
     return concatBytes(
-      pack([this.baseTx, this.nodeId], codec),
+      pack([this.baseTx], codec),
+      new Bytes(this.nodeId.toBytes()).toBytes(),
       codec.PackPrefix(this.signer),
       packList(this.stake, codec),
       codec.PackPrefix(this.validatorRewardsOwner),
       codec.PackPrefix(this.delegatorRewardsOwner),
-      codec.PackPrefix(this.owner),
-      this.shares.toBytes(),
-      this.weight.toBytes(),
+      codec.PackPrefix(this.validatorAuthority),
+      this.delegationShares.toBytes(),
       this.autoCompoundRewardShares.toBytes(),
       this.period.toBytes(),
     );

--- a/src/vms/pvm/etna-builder/builder.test.ts
+++ b/src/vms/pvm/etna-builder/builder.test.ts
@@ -1453,7 +1453,6 @@ describe('./src/vms/pvm/etna-builder/builder.test.ts', () => {
         OutputOwners.fromNative([toAddress], 0n, 1),
         OutputOwners.fromNative([toAddress], 0n, 1),
         new Int(shares),
-        new BigIntPr(stakeAmount),
         new Int(autoCompoundRewardShares),
         new BigIntPr(period),
       );

--- a/src/vms/pvm/etna-builder/builder.ts
+++ b/src/vms/pvm/etna-builder/builder.ts
@@ -2019,7 +2019,6 @@ export const newAddAutoRenewedValidatorTx: TxBuilderFn<
     delegatorOutputOwners,
     ownerOutputOwners,
     new Int(shares),
-    new BigIntPr(weight),
     new Int(autoCompoundRewardShares),
     new BigIntPr(period),
   );

--- a/src/vms/pvm/txs/fee/complexity.ts
+++ b/src/vms/pvm/txs/fee/complexity.ts
@@ -472,7 +472,7 @@ const addAutoRenewedValidatorTxComplexity = (
     getOutputComplexity(tx.stake),
     getOwnerComplexity(tx.getValidatorRewardsOwner()),
     getOwnerComplexity(tx.getDelegatorRewardsOwner()),
-    getOwnerComplexity(tx.getOwner()),
+    getOwnerComplexity(tx.getValidatorAuthority()),
   );
 };
 

--- a/src/vms/pvm/txs/fee/constants.ts
+++ b/src/vms/pvm/txs/fee/constants.ts
@@ -282,6 +282,7 @@ export const INTRINSIC_ADD_AUTO_RENEWED_VALIDATOR_TX_COMPLEXITIES: Dimensions =
   {
     [FeeDimensions.Bandwidth]:
       INTRINSIC_BASE_TX_COMPLEXITIES[FeeDimensions.Bandwidth] +
+      INT_LEN + // Node ID length prefix
       SHORT_ID_LEN + // Node ID
       INT_LEN + // Signer typeID
       INT_LEN + // Num stake outs
@@ -289,7 +290,6 @@ export const INTRINSIC_ADD_AUTO_RENEWED_VALIDATOR_TX_COMPLEXITIES: Dimensions =
       INT_LEN + // Delegator rewards typeID
       INT_LEN + // Owner typeID
       INT_LEN + // Delegation shares
-      LONG_LEN + // Weight
       INT_LEN + // AutoCompoundRewardShares
       LONG_LEN, // Period
     [FeeDimensions.DBRead]: 0,


### PR DESCRIPTION
When the ACP-236 support was first added here in AJS (https://github.com/ava-labs/avalanchejs/pull/988), the AvalancheGo implementation was still on a pull-request stage (although said to be ready to get implemented in AJS, too):

* https://github.com/ava-labs/avalanchejs/pull/988

However, during review some breaking changes have been made:

* [NodeID changed encoding](https://github.com/ava-labs/avalanchego/pull/5201#discussion_r3305613610)
* [Weight field got removed](https://github.com/ava-labs/avalanchego/pull/5201#discussion_r3305658169)

Also, some fields go renamed (`owner` -> `validatorAuthority`, `shares` -> `delegationShares`)


This PR aligns us back with the AvalancheGo implementation.